### PR TITLE
Change ckeditor/templates url to https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
             "version": "4.5.7",
             "dist": {
               "type": "zip",
-              "url": "http://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
+              "url": "https://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
               "reference": "master"
             }
           }

--- a/composer.lock
+++ b/composer.lock
@@ -159,7 +159,7 @@
             "version": "4.5.7",
             "dist": {
                 "type": "zip",
-                "url": "http://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
+                "url": "https://download.ckeditor.com/templates/releases/templates_4.5.7.zip",
                 "reference": "master",
                 "shasum": null
             },


### PR DESCRIPTION
When using the original `http` I get the following error:
```
- Installing ckeditor/templates (4.5.7): Downloading

     [Composer\Downloader\TransportException]
     Your configuration does not allow connections to http://download.ckeditor.com/templates/releases/templates_4.5.7.zip. See https://getcomposer.org/doc/06-config.md#secure-http for details.
```

I cant see a reason why we wouldnt use https for this...