### PR TITLE
Run updatedb if necessary on container startup

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -40,6 +40,11 @@ if [[ "${CF_INSTANCE_INDEX}" = "0" ]]; then
   # Import the config from sync dir
   drush config-import -y
 
+  UPDATEDB_STATUS=$(drush updatedb-status 2>/dev/null)
+  if [[ $UPDATEDB_STATUS != "" ]]; then
+    drush updatedb --no-cache-clear
+  fi
+
 else
   echo "I am not the first instance"
 fi

--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -33,13 +33,10 @@ if [[ "${CF_INSTANCE_INDEX}" = "0" ]]; then
     fi
   fi
 
-  # Fix for https://www.drupal.org/node/2583113
-  # TODO think this isnt needed anymore
-  # drush ev '\Drupal::entityManager()->getStorage("shortcut_set")->load("default")->delete();'
-
   # Import the config from sync dir
   drush config-import -y
 
+  # Run updatedb if necessary
   UPDATEDB_STATUS=$(drush updatedb-status 2>/dev/null)
   if [[ $UPDATEDB_STATUS != "" ]]; then
     drush updatedb --no-cache-clear


### PR DESCRIPTION
`drush updatedb-status` outputs an empty string if no updates are required.

I havent seen whether maintenance mode isa actually required when using `drush updatedb`. It would be [easy enough to enable](https://www.drupal.org/docs/user_guide/en/extend-maintenance.html) before hand, but as a prerequisite before touching maintenance mode we need to save it's initial state, which doesnt work. for me i.e. `drush sget system.maintenance_mode` returns an empty string for me in staging even when maintenance mode is enabled.

So for now I'm proposing we dont touch maintenance mode. Testing might prove this a terrible idea 🤞 