### PR TITLE
Run php lint on modified php files

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,15 +15,25 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Add vendored bin dir to PATH
 PATH="${SCRIPT_DIR}/../bin:${PATH}"
 
-pushd docroot
+if [ -n "$CIRCLE_BRANCH" ]; then
+  # For efficiency we only want to run certain tests against deviations from
+  # the base branch, which for now we assume is develop.
+  BASE_BRANCH=develop
+  if [[ $CIRCLE_BRANCH != $BASE_BRANCH ]] ; then
 
-  find . -name \*.php ! -name global_namespace_php5.php -type f -print0 | xargs -0 -n1 php -l
+    #Run php lint, but only against modified php files
+    git diff --name-only origin/${BASE_BRANCH}... -- '*.php' | xargs -n1 php -l
 
-  pushd core
+    # If anything in core has changed, run its phpunit
+    for file in $(git diff --name-only origin/${BASE_BRANCH}...); do
+      if [[ $file == docroot/core* ]]; then
+        pushd docroot/core
+          phpunit --testsuite=unit --exclude-group \
+            Composer,DependencyInjection,PageManager,jsonapi
+        popd
+        break
+      fi
+    done
 
-    phpunit --testsuite=unit --exclude-group \
-      Composer,DependencyInjection,PageManager,jsonapi
-
-  popd
-
-popd
+  fi
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,7 +15,15 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Add vendored bin dir to PATH
 PATH="${SCRIPT_DIR}/../bin:${PATH}"
 
-cd docroot/core
+pushd docroot
 
-phpunit --testsuite=unit --exclude-group \
-  Composer,DependencyInjection,PageManager,jsonapi
+  find . -name \*.php ! -name global_namespace_php5.php -type f -print0 | xargs -0 -n1 php -l
+
+  pushd core
+
+    phpunit --testsuite=unit --exclude-group \
+      Composer,DependencyInjection,PageManager,jsonapi
+
+  popd
+
+popd


### PR DESCRIPTION
Running php lint across the whole code base took a while, so this will only lint the changed files.

I also changed calling core's phpunit tests so they run only if something has changed in core.

I'm ignoring the case of the master branch for now - will be looking into what kind of testing to do on develop and master branches next.