### PR TITLE
Add libpng-dev and gd php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ RUN apt-get update && apt-get install -y \
 	git \
 	vim \
 	wget \
-	libbz2-dev; \
-	docker-php-ext-install bz2;
+	libbz2-dev \
+	libpng-dev; \
+	docker-php-ext-install bz2 gd;
 
 # Install composer
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \


### PR DESCRIPTION
Currently these are being installed each circle build, which is adding 30+ seconds to the build. By adding them to the docker image, we wont need to do it every build so it should be faster.

After this is merged to develop, it will take a little while for docker hub to update [the docker image](https://hub.docker.com/r/govau/dta-website-rebuild/), but after that's done I will add a new PR to remove these lines from circle.