### PR TITLE
Test preprocess.sh as part of the integration test initialisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
     docker:
       - image: govau/dta-website-rebuild:latest
         # Gotcha - if you DONT specify command, then the entrypoint in the image
-        # is not run either
-        command: apache2ctl -D FOREGROUND
+        # is not run either. But we start the application further down just before running
+        # the integration tests.
         environment:
           VCAP_SERVICES: "{\"mysql\":[{\"binding_name\":null,\"credentials\":{\"host\":\"db\",\"name\":\"drupal\",\"password\":\"password\",\"port\":3306,\"username\":\"drupal\"},\"label\":\"mysql\",\"name\": \"dta-website-rebuild-db\",\"tags\":[\"mysql\"]}],\"user-provided\":[{\"credentials\":{\"SMTP_PASSWORD\":\"password\"},\"instance_name\":\"ups-website-redev\",\"label\":\"user-provided\",\"name\":\"ups-website-redev\",\"syslog_drain_url\":\"\",\"tags\":[],\"volume_mounts\":[]},{\"binding_name\":null,\"credentials\":{\"access_key\":\"AKIAIFOO\",\"secret_key\":\"BAR\"},\"instance_name\":\"ups-aws\",\"label\":\"user-provided\",\"name\":\"ups-aws\",\"syslog_drain_url\":\"\",\"tags\":[],\"volume_mounts\":[]}]}"
       - image: mariadb:10.2
@@ -46,6 +46,7 @@ jobs:
           key: composer-v1-{{ checksum "composer.lock" }}
           paths:
             - vendor
+      - run: ./scripts/test.sh
       - run:
           name: Install dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
@@ -54,7 +55,10 @@ jobs:
       - run:
           name: Wait for db to start
           command: dockerize -wait tcp://db:3306 -timeout 1m
-      - run: ./scripts/test.sh
+      - run: ./.circleci/init.sh
+      - run:
+          command: apache2ctl -D FOREGROUND
+          background: true
       - run: ./scripts/int-test.sh
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
           MYSQL_RANDOM_ROOT_PASSWORD: "yes"
     working_directory: /app
     steps:
-      - run: apt-get install -y libbz2-dev libpng-dev
-      - run: docker-php-ext-install bz2
-      - run: docker-php-ext-install gd
       - run: composer self-update
       - checkout
       - run: git submodule sync

--- a/.circleci/init.sh
+++ b/.circleci/init.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Exit immediately if there is an error
+set -e
+
+# Cause a pipeline (for example, curl -s http://sipb.mit.edu/ | grep foo) to produce a failure return code if any command errors not just the last command of the pipeline.
+set -o pipefail
+
+# Print shell input lines as they are executed
+# DO NOT USE THIS IF YOU USE SECRETS IN THIS SCRIPT
+set -x
+
+# Include build env vars
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../scripts/buildrc"
+
+# Fixup circleci permissions for drupal
+# The directory <em class="placeholder">sites/default/files</em> is not writable
+chown -R www-data:www-data  ${SCRIPT_DIR}/../docroot/sites/default/files/
+# The govCMS installer requires write permissions to sites/default/settings.php
+chown -R www-data:www-data  ${SCRIPT_DIR}/../docroot/sites/default/settings.php
+
+drush -y site-install
+
+# Fix for error "Entities exist of type <em class="placeholder">Shortcut link</em> and
+# <em class="placeholder">Shortcut set</em> <em class="placeholder">Default</em>.
+# These entities need to be deleted before importing."
+drush ev '\Drupal::entityManager()->getStorage("shortcut_set")->load("default")->delete();'
+
+# We want to mimic the app running on cloudfoundry, so we call
+# preprocess.sh before starting the application to hopefully pick up
+# any issues there.
+CF_INSTANCE_INDEX=0 DRUPAL_UUID="59f85df3-5f18-45dd-bf6a-40977b57a842" \
+  ./scripts/preprocess.sh

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "drupal/paragraphs": "^1.2",
         "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1.0",
-        "drupal/redirect": "^1.1",
+        "drupal/redirect": "^1.x-dev",
         "drupal/respondjs": "^1.1",
         "drupal/restui": "^1.15",
         "drupal/robotstxt": "^1.1",
@@ -228,6 +228,9 @@
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
         "patches": {
+          "drupal/redirect": {
+            "Unable to import configuration": "https://www.drupal.org/files/issues/redirect-catch-route-does-not-exist-2932263-15.patch"
+          },
           "drupal/node_title_validation": {
             "Unable to import configuration": "https://www.drupal.org/files/issues/2855289-7.patch",
             "Unique node title validation restricts node edit": "https://www.drupal.org/files/issues/unique_node_title-2828307-5.patch"

--- a/scripts/buildrc
+++ b/scripts/buildrc
@@ -8,6 +8,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Add vendored bin dir to PATH
 PATH="${SCRIPT_DIR}/../bin:${PATH}"
 
+# Add included mysql cli to PATH
+PATH="${HOME}/scripts/mysql:${PATH}"
+
 # Note its nice to be able to run the same script locally as well as in CI,
 # so we dont rely on circle env vars being available.
 

--- a/scripts/int-test.sh
+++ b/scripts/int-test.sh
@@ -13,15 +13,4 @@ set -x
 # Include build env vars
 source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/buildrc"
 
-# Fixup circleci permissions for drupal
-# The directory <em class="placeholder">sites/default/files</em> is not writable
-chown -R www-data:www-data  ${SCRIPT_DIR}/../docroot/sites/default/files/
-# The govCMS installer requires write permissions to sites/default/settings.php
-chown -R www-data:www-data  ${SCRIPT_DIR}/../docroot/sites/default/settings.php
-
-drush -y site-install
-
-# Set the site uuid to match our config
-drush config-set -y "system.site" uuid "59f85df3-5f18-45dd-bf6a-40977b57a842"
-
 behat --strict --stop-on-failure --config tests/behat/behat.yml


### PR DESCRIPTION
I wanted to make a change to `scripts/preprocess.sh`, but then realised that I wouldnt be able to test it until I did a `cf push`. So I've made it now run as part of the integration test in circle. 

There might be some more room for improvement, but I spent far too long wrestling with `drush config-import` and I think this can be merged now.