### PR TITLE
Use mysql 5.7 in docker and circle so we match cloud.gov.au

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         # the integration tests.
         environment:
           VCAP_SERVICES: "{\"mysql\":[{\"binding_name\":null,\"credentials\":{\"host\":\"db\",\"name\":\"drupal\",\"password\":\"password\",\"port\":3306,\"username\":\"drupal\"},\"label\":\"mysql\",\"name\": \"dta-website-rebuild-db\",\"tags\":[\"mysql\"]}],\"user-provided\":[{\"credentials\":{\"SMTP_PASSWORD\":\"password\"},\"instance_name\":\"ups-website-redev\",\"label\":\"user-provided\",\"name\":\"ups-website-redev\",\"syslog_drain_url\":\"\",\"tags\":[],\"volume_mounts\":[]},{\"binding_name\":null,\"credentials\":{\"access_key\":\"AKIAIFOO\",\"secret_key\":\"BAR\"},\"instance_name\":\"ups-aws\",\"label\":\"user-provided\",\"name\":\"ups-aws\",\"syslog_drain_url\":\"\",\"tags\":[],\"volume_mounts\":[]}]}"
-      - image: mariadb:10.2
+      - image: mysql:5.7
         environment:
           MYSQL_DATABASE: drupal
           MYSQL_USER: drupal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   db:
-    image: mysql
+    image: mysql:5.7
     volumes:
     - mysql-data-volume:/var/lib/mysql
     environment:


### PR DESCRIPTION
I havent noticed any issues using mariadb, but we should probably match [the RDS broker's mysql that is used on cloud.gov.au](https://github.com/AusDTO/pe-rds-broker/blob/master/config-govau.yml#L122) 