### PR TITLE
Add libfontconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
 	vim \
 	wget \
 	libbz2-dev \
+	libfontconfig \
 	libpng-dev; \
 	docker-php-ext-install bz2 gd;
 


### PR DESCRIPTION
I just noticed that when running `composer install` locally in the docker image, I got this error: 
```
> PhantomInstaller\Installer::installPhantomJS
/app/bin/phantomjs: error while loading shared libraries: libfontconfig.so.1: cannot open shared object file: No such file or directory
Caught exception while checking PhantomJS version:
Undefined offset: 0
  - Installing phantomjs (2.1.1): Downloading (100%)
```
Havent noticed any problems, and circleci doesnt give this error, but we may as well add this dependency to docker.