### PR TITLE
Remove drupal/redirect caret version range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "drupal/paragraphs": "^1.2",
         "drupal/password_policy": "^3.0",
         "drupal/pathauto": "^1.0",
-        "drupal/redirect": "^1.x-dev",
+        "drupal/redirect": "1.x-dev",
         "drupal/respondjs": "^1.1",
         "drupal/restui": "^1.15",
         "drupal/robotstxt": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "df79601b2f2753e7c5e9cef8a7288e8e",
+    "content-hash": "6d4054465789a473da522cd7e4eb5ad3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1329,7 +1329,7 @@
                 "Apache-2.0"
             ],
             "description": "The official PHP client library for disqus, with added composer.json.",
-            "time": "2013-11-07 10:47:07"
+            "time": "2013-11-07T10:47:07+00:00"
         },
         {
             "name": "drupal-composer/drupal-scaffold",
@@ -3954,7 +3954,7 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/link_css"
             },
-            "time": "2016-11-08 03:19:30"
+            "time": "2016-11-08T03:19:30+00:00"
         },
         {
             "name": "drupal/linkit",
@@ -5104,17 +5104,11 @@
         },
         {
             "name": "drupal/redirect",
-            "version": "1.1.0",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/redirect",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "32916081c436ea325b51bc5b3ec840fa19857cf7"
+                "reference": "24e1c6c6155b50a4e14eb94b986b50491499d782"
             },
             "require": {
                 "drupal/core": "~8"
@@ -5125,12 +5119,15 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1520897880",
+                    "version": "8.x-1.1+0-dev",
+                    "datestamp": "1520897580",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Unable to import configuration": "https://www.drupal.org/files/issues/redirect-catch-route-does-not-exist-2932263-15.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5151,7 +5148,8 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "http://cgit.drupalcode.org/redirect"
-            }
+            },
+            "time": "2018-03-12T23:29:57+00:00"
         },
         {
             "name": "drupal/respondjs",
@@ -5471,7 +5469,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc2",
-                    "datestamp": "1519829285",
+                    "datestamp": "1521362884",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -5552,7 +5550,7 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/search_api_page"
             },
-            "time": "2018-03-11 13:00:40"
+            "time": "2018-03-11T13:00:40+00:00"
         },
         {
             "name": "drupal/seckit",
@@ -6325,7 +6323,7 @@
                 "source": "http://cgit.drupalcode.org/typogrify",
                 "issues": "http://drupal.org/project/typogrify"
             },
-            "time": "2017-06-07 16:52:40"
+            "time": "2017-06-07T16:52:40+00:00"
         },
         {
             "name": "drupal/username_enumeration_prevention",
@@ -6947,7 +6945,7 @@
                 "reference": "master"
             },
             "type": "drupal-custom-theme",
-            "time": "2018-03-14 22:00:33"
+            "time": "2018-03-19T02:00:29+00:00"
         },
         {
             "name": "govau/dta-uikit-base",
@@ -6958,7 +6956,7 @@
                 "reference": "master"
             },
             "type": "drupal-custom-theme",
-            "time": "2018-03-14 21:57:49"
+            "time": "2018-03-14T21:57:49+00:00"
         },
         {
             "name": "govau/dta-uikit-base-theme",
@@ -6969,7 +6967,7 @@
                 "reference": "master"
             },
             "type": "drupal-custom-theme",
-            "time": "2018-03-06 04:29:05"
+            "time": "2018-03-14T21:57:49+00:00"
         },
         {
             "name": "grasmash/yaml-expander",
@@ -14055,6 +14053,7 @@
         "drupal/entity_embed": 10,
         "drupal/filefield_paths": 10,
         "drupal/link_css": 20,
+        "drupal/redirect": 20,
         "drupal/s3fs": 15,
         "drupal/search_api_autocomplete": 10,
         "drupal/search_api_page": 20,


### PR DESCRIPTION
I was having this error during `composer install`:
```
- The requested package drupal/redirect ^1.x-dev exists as drupal/redirect[dev-1.x, 1.x-dev, 1.1.0, 1.0.0, 1.0.0-beta1, 1.0.0-alpha5, 1.0.0-alpha4, 1.0.0-alpha3, 1.0.0-alpha2, 1.0.0-alpha1] but these are rejected by your constraint.
```
I think the caret should be removed when using dev releases, seems to fix it for me anyway
