### PR TITLE
Further updates to settings. Moved bucket names into settings.php as …

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/advagg_css_minify.settings.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/advagg_css_minify.settings.yml
@@ -1,3 +1,4 @@
-minifier: 2
+minifier: 1
 _core:
   default_config_hash: kjloycaorPxucU1MyqCvnQPEHqOfcgdNVIfFzki6wOE
+add_license: 0

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/advagg_js_minify.settings.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/advagg_js_minify.settings.yml
@@ -1,4 +1,4 @@
-add_license: true
+add_license: false
 minifier: 5
 ratio_max: 0.9
 ratio_min: 0.1

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/system.performance.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/system.performance.yml
@@ -3,7 +3,7 @@ cache:
     max_age: 300
     use_internal: false
 css:
-  preprocess: false
+  preprocess: true
   gzip: true
 fast_404:
   enabled: true
@@ -11,7 +11,7 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: false
+  preprocess: true
   gzip: true
 stale_file_threshold: 2592000
 _core:

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -840,7 +840,7 @@ if(isset($_ENV['VCAP_SERVICES'])) {
     foreach ($service_list as $some_service) {
       // Look for a service where the name matches the appopriate environment.
 
-      if ($_ENV['ENVIRONMENT'] === 'development') {
+      if ($_ENV['ENVIRONMENT'] === 'test') {
         if ($some_service['name'] === 'dta-website-rebuild-test-aws-ups') {
           $aws_service[] = $some_service;
         }
@@ -922,29 +922,17 @@ if(isset($_ENV['ENVIRONMENT'])) {
   $environment = 'local';
 }
 
-// switch ($environment) {
-//   case 'production':
-//     $config['config_split.config_split.development_configuration']['status'] = FALSE;
-//     $settings['s3fs.settings']['no_rewrite_cssjs'] = TRUE;
-//     $config['system.performance']['css']['preprocess'] = TRUE;
-//     $config['system.performance']['js']['preprocess'] = TRUE;
-//     break;
-//   case 'staging':
-//     $config['config_split.config_split.development_configuration']['status'] = FALSE;
-//     $settings['s3fs.settings']['no_rewrite_cssjs'] = TRUE;
-//     $config['system.performance']['css']['preprocess'] = TRUE;
-//     $config['system.performance']['js']['preprocess'] = TRUE;
-//     break;
-//   case 'development':
-//     $config['config_split.config_split.development_configuration']['status'] = TRUE;
-//     $settings['s3fs.settings']['no_rewrite_cssjs'] = FALSE;
-//     $config['system.performance']['css']['preprocess'] = FALSE;
-//     $config['system.performance']['js']['preprocess'] = FALSE;
-//     break;
-//   default:
-//     $config['config_split.config_split.development_configuration']['status'] = TRUE;
-//     $settings['s3fs.settings']['no_rewrite_cssjs'] = FALSE;
-//     $config['system.performance']['css']['preprocess'] = FALSE;
-//     $config['system.performance']['js']['preprocess'] = FALSE;
-//     break;
-// }
+switch ($environment) {
+   case 'production':
+    $config['s3fs.settings']['bucket'] = 'dta-www-drupal-20180130215411153400000001';
+    break;
+  case 'staging':
+    $config['s3fs.settings']['bucket'] = 'dta-www-drupal-staging-20180504063601229200000001';
+    break;
+  case 'test':
+    $config['s3fs.settings']['bucket'] = 'dta-www-drupal-test-20180221050325640300000001';
+    break;
+  default:
+    $config['s3fs.settings']['bucket'] = '';
+    break;
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -15,4 +15,4 @@ applications:
   - route: dta-website-rebuild-test.apps.y.cld.gov.au
   env:
     DRUPAL_UUID: "59f85df3-5f18-45dd-bf6a-40977b57a842"
-    ENVIRONMENT: development
+    ENVIRONMENT: test


### PR DESCRIPTION
…everything else is kept in $config or $settings. Remember that the bucket names will remain in the form. It shouldn't matter if this config key gets pushed up but maybe avoid it. Updated name for 'development' to 'test'.  Removed complicated logic around performance and aggregation settings: they will now be the same for the three cloud environments.