### PR TITLE
Update entity reference field

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_related_content.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_related_content.yml
@@ -4,7 +4,13 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_related_content
+    - node.type.blog_post
+    - node.type.external_link
+    - node.type.govcms_event
     - node.type.landing_page
+    - node.type.landing_page_level_2
+    - node.type.news_item
+    - node.type.page
 id: node.landing_page.field_related_content
 field_name: field_related_content
 entity_type: node
@@ -16,10 +22,19 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: views
+  handler: 'default:node'
   handler_settings:
-    view:
-      view_name: content_reference
-      display_name: entity_reference_1
-      arguments: {  }
+    target_bundles:
+      blog_post: blog_post
+      govcms_event: govcms_event
+      external_link: external_link
+      landing_page_level_2: landing_page_level_2
+      landing_page: landing_page
+      news_item: news_item
+      page: page
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: blog_post
 field_type: entity_reference

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_related_content.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_related_content.yml
@@ -4,7 +4,13 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_related_content
+    - node.type.blog_post
+    - node.type.external_link
+    - node.type.govcms_event
+    - node.type.landing_page
     - node.type.landing_page_level_2
+    - node.type.news_item
+    - node.type.page
 id: node.landing_page_level_2.field_related_content
 field_name: field_related_content
 entity_type: node
@@ -16,10 +22,19 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: views
+  handler: 'default:node'
   handler_settings:
-    view:
-      view_name: content_reference
-      display_name: entity_reference_1
-      arguments: {  }
+    target_bundles:
+      blog_post: blog_post
+      govcms_event: govcms_event
+      external_link: external_link
+      landing_page_level_2: landing_page_level_2
+      landing_page: landing_page
+      news_item: news_item
+      page: page
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: blog_post
 field_type: entity_reference

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_related_content.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_related_content.yml
@@ -4,6 +4,12 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_related_content
+    - node.type.blog_post
+    - node.type.external_link
+    - node.type.govcms_event
+    - node.type.landing_page
+    - node.type.landing_page_level_2
+    - node.type.news_item
     - node.type.page
 id: node.page.field_related_content
 field_name: field_related_content
@@ -16,10 +22,19 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: views
+  handler: 'default:node'
   handler_settings:
-    view:
-      view_name: content_reference
-      display_name: entity_reference_1
-      arguments: {  }
+    target_bundles:
+      blog_post: blog_post
+      govcms_event: govcms_event
+      external_link: external_link
+      landing_page_level_2: landing_page_level_2
+      landing_page: landing_page
+      news_item: news_item
+      page: page
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: blog_post
 field_type: entity_reference


### PR DESCRIPTION
This commit updates the entity reference field on Landing pages (levels 1 and 2) and pages to use an ordinary entity reference rather than an entity view.