### PR TITLE
Change rebuild to only happen on first instance so that tasks don't kick this off

### DIFF
--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -62,10 +62,9 @@ if [[ "${CF_INSTANCE_INDEX}" = "0" ]]; then
   else
     echo "Currently running in a local environment (or an environment without the correct environment variables set!)"
   fi
+  drush cache-rebuild
 else
   echo "I am not the first instance"
 fi
-
-drush cache-rebuild
 
 echo "preprocess.sh finished"


### PR DESCRIPTION
(as it locks the site up while it happens)