### PR TITLE
Removed unnecessary PHP modules

### DIFF
--- a/.bp-config/php/php.ini.d/extensions.ini
+++ b/.bp-config/php/php.ini.d/extensions.ini
@@ -1,8 +1,5 @@
-extension=pdo.so
 extension=pdo_mysql.so
-extension=gd.so
 extension=mysqli.so
-extension=openssl.so
 
 upload_max_filesize=64M
 post_max_size=64M

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/login_security.settings.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/login_security.settings.yml
@@ -1,4 +1,4 @@
-track_time: 0
+track_time: 24
 user_wrong_count: 5
 host_wrong_count: 0
 host_wrong_count_hard: 0
@@ -7,6 +7,8 @@ disable_core_login_error: 1
 notice_attempts_available: 1
 last_login_timestamp: 1
 last_access_timestamp: 0
+user_blocked_email_user: ''
+login_activity_email_user: ''
 notice_attempts_message: 'Unrecognised username or password. Have you <a href="/user/password">forgotten your password</a>?'
 host_soft_banned: 'This host is not allowed to log in to @site. Please contact your site administrator.'
 host_hard_banned: 'The IP address @ip is banned at @site, and will not be able to access any of its content from now on. Please contact the site administrator.'
@@ -17,5 +19,5 @@ login_activity_email_subject: 'Security information: Unexpected login activity h
 login_activity_email_body: 'The configured threshold of @activity_threshold logins has been reached with a total of @tracking_current_count invalid login attempts. You should review your log information about login attempts at @site.'
 _core:
   default_config_hash: QEy3AwbqJ6ehvORjyspzixpU3QgZWWAUPIK1g-4QD1c
-user_blocked_notification_emails: null
-login_activity_notification_emails: null
+login_activity_notification_emails: website@digital.gov.au
+user_blocked_notification_emails: website@digital.gov.au


### PR DESCRIPTION
These modules are already included in PHP/CF Buildpack. Installing them via `.bp-config/php/php.ini.d/extensions.ini` caused the system to report multiple instances of modules being installed.

This commit also adds a configuration for `login_security`.

Some database cleanup was required to remove the `import_recruiterbox` module completely. This has been performed on all sites.