### PR TITLE
Update caching on news and blogs views

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.news_and_blogs_facets.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.news_and_blogs_facets.yml
@@ -282,10 +282,8 @@ display:
       display_extenders:
         metatag_display_extender: {  }
       path: news-blogs/%
-      cache:
-        type: none
       defaults:
-        cache: false
+        cache: true
         use_ajax: false
       menu:
         type: normal


### PR DESCRIPTION
This commit updates the caching on the news and blogs views to ensure the latest blogs appear correctly.