### PR TITLE
Updated startup scripts

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -2,5 +2,6 @@
 	"COMPOSER_VENDOR_DIR": "{BUILD_DIR}/vendor",
 	"COMPOSER_BIN_DIR": "{BUILD_DIR}/bin",
   "ZEND_EXTENSIONS": ["opcache"],
-	"WEBDIR": "docroot"
+	"WEBDIR": "docroot",
+	"ADDITIONAL_PREPROCESS_CMDS": ["./scripts/preprocess.sh"]
 }

--- a/.bp-config/php/php.ini.d/extensions.ini
+++ b/.bp-config/php/php.ini.d/extensions.ini
@@ -3,3 +3,5 @@ extension=mysqli.so
 
 upload_max_filesize=64M
 post_max_size=64M
+memory_limit=1024M
+max_execution_time=120

--- a/.circleci/init.sh
+++ b/.circleci/init.sh
@@ -26,5 +26,8 @@ drush -y site-install
 # These entities need to be deleted before importing."
 drush ev '\Drupal::entityManager()->getStorage("shortcut_set")->load("default")->delete();'
 
-# We want to mimic the app running on cloudfoundry.
-CF_INSTANCE_INDEX=0 DRUPAL_UUID="59f85df3-5f18-45dd-bf6a-40977b57a842"
+# We want to mimic the app running on cloudfoundry, so we call
+# preprocess.sh before starting the application to hopefully pick up
+# any issues there.
+CF_INSTANCE_INDEX=0 DRUPAL_UUID="59f85df3-5f18-45dd-bf6a-40977b57a842" \
+  ./scripts/start.sh

--- a/manifest-beta.yml
+++ b/manifest-beta.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: dta-website-rebuild
-  memory: 512M
+  memory: 1G
   disk_quota: 2G
   instances: 2
   path: .

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: dta-website-rebuild-staging
-  memory: 512M
+  memory: 1G
   disk_quota: 2G
   instances: 2
   path: .

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,7 @@
 ---
 applications:
 - name: dta-website-rebuild-test
-  command: ./scripts/start.sh
-  memory: 512M
+  memory: 1G
   disk_quota: 2G
   instances: 2
   path: .

--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# Exit immediately if there is an error
+set -e
+
+# Cause a pipeline (for example, curl -s http://sipb.mit.edu/ | grep foo) to produce a failure return code if any command errors not just the last command of the pipeline.
+set -o pipefail
+
+# Print shell input lines as they are read.
+set -x
+
+# We only want these scripts to happen here if we are running in the test environment.
+# The other environments will get the same treatment via Circle.
+
+if [[ -n ${ENVIRONMENT+x} ]]; then
+  echo "Currently running in the ${ENVIRONMENT} environment."
+  if [[ ${ENVIRONMENT} = "test" ]]; then
+
+    # Add included mysql cli to PATH
+    PATH="${HOME}/scripts/mysql:${PATH}"
+
+    # Add vendored bin dir to PATH
+    PATH="${HOME}/bin:${PATH}"
+
+    cd docroot
+
+    # Only execute on the first application instance
+    if [[ "${CF_INSTANCE_INDEX}" = "0" ]]; then
+      echo "I am the first instance"
+
+      drush status
+
+      CACHE_FLAG="false"
+
+      # If DRUPAL_UUID is defined, change our UUID to it if necessary
+      if [[ -n ${DRUPAL_UUID+x} ]]; then
+        CURRENT_UUID=$(drush cget "system.site" --format=json | jq -r .uuid )
+        if [[ ${DRUPAL_UUID} != ${CURRENT_UUID} ]]; then
+          drush config-set -y "system.site" uuid "${DRUPAL_UUID}"
+        fi
+      fi
+
+      # Import the config from sync dir
+      config_status_file=$(mktemp)
+
+      CONFIG_STATUS=$(drush config-status &>$config_status_file)
+
+      printf "%s\n" "$CONFIG_STATUS"
+
+      haystack=$(< $config_status_file)
+
+      case "${haystack}" in
+        *"No differences"*)
+          printf "%s\n" "$CONFIG_STATUS"
+          exit
+          ;;
+        *)
+          echo "Updates required."
+          printf "%s\n" "$CONFIG_STATUS"
+          drush config-import -y
+          CACHE_FLAG="true"
+          ;;
+      esac
+
+      # Run updatedb if necessary
+      UPDATEDB_STATUS=$(drush updatedb-status 2>/dev/null)
+      if [[ $UPDATEDB_STATUS != "" ]]; then
+        printf "%s\n" "$UPDATEDB_STATUS"
+        echo "Updates required"
+        error_file=$(mktemp)
+        UPDATEDB_OUTPUT+=$(drush updatedb -y --entity-updates --no-cache-clear 2>$error_file)
+        printf "%s\n" "$UPDATEDB_OUTPUT"
+        err=$(< $error_file)
+        case "${err}" in
+          *"Update failed"*)
+            echo "An error occured!"
+            printf "%s\n" "$UPDATEDB_OUTPUT"
+            exit 1
+            ;;
+          *)
+            echo "Updates performed without error. Please check output."
+            printf "%s\n" "$UPDATEDB_OUTPUT"
+            CACHE_FLAG="true"
+            ;;
+        esac
+      else
+        echo "No updates required."
+      fi
+
+      # Clear the caches if required.
+      if [ "$CACHE_FLAG" = "true" ]; then
+        drush cache-rebuild
+      fi
+    else
+      echo 'I am not the first instance'
+    fi
+  fi
+else
+  echo "Currently running in a local environment (or an environment without the correct environment variables set!)"
+fi
+
+echo "preprocess.sh finished"


### PR DESCRIPTION
This commit updates the deployment system and start-up scripts. It turned out that using the `command` key in `manifest.yml` is not supported by the PHP buildpack, so required server things were not starting correctly or at all. Basically this is a mix of the original way of doing it and the new one as added by https://github.com/govau/dta-website-rebuild/pull/449.
 - Updates memory for the app to 1G.
 - Increases the PHP `memory_limit` and `max_execution_time` to resolve issues with Drush having to do a lot at once.
 - Adds the preprocess.sh script back into `options.json` and adds checks to make sure it only runs in the test environment.
 - Changes the `start.sh` script to suit Circle.