### PR TITLE
Minor updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,9 @@ jobs:
       - run:
           name: Deploying to cloud.gov.au
           command: ./scripts/deploy.sh
+      - run:
+          name: Updating configuration and database
+          command: ./scripts/start.sh
 workflows:
   version: 2
   test-and-deploy:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.assessment_report.teaser.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.assessment_report.teaser.yml
@@ -28,7 +28,12 @@ hidden:
   field_assessment_method: true
   field_body: true
   field_date: true
+  field_dss_assessment: true
+  field_introduction: true
   field_lead_assessor: true
+  field_pass_rationale: true
   field_phase: true
+  field_recommendations: true
   field_related_content: true
+  field_result_assessment: true
   field_service_manager: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.taxonomy_term.blog_authors.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.taxonomy_term.blog_authors.default.yml
@@ -9,6 +9,19 @@ dependencies:
   module:
     - image
     - text
+third_party_settings:
+  ds:
+    layout:
+      id: layout_onecol
+      library: layout_discovery/onecol
+      disable_css: false
+      entity_classes: all_classes
+      settings: {  }
+    regions:
+      content:
+        - field_author_image
+  ds_chains:
+    fields: {  }
 id: taxonomy_term.blog_authors.default
 targetEntityType: taxonomy_term
 bundle: blog_authors

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/search_api.server.database_search.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/search_api.server.database_search.yml
@@ -17,3 +17,4 @@ backend_config:
     suggest_suffix: true
     suggest_words: false
   matching: partial
+  partial_matches: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.dss_assessment_results.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.dss_assessment_results.yml
@@ -202,17 +202,6 @@ display:
           field_api_classes: false
           plugin_id: field
       filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-          group: 1
         type:
           id: type
           table: node_field_data

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/workflows.workflow.editorial.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/workflows.workflow.editorial.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - node.type.assessment_report
     - node.type.blog_post
     - node.type.external_link
     - node.type.govcms_event
@@ -86,6 +87,7 @@ type_settings:
         - published
   entity_types:
     node:
+      - assessment_report
       - blog_post
       - external_link
       - govcms_event


### PR DESCRIPTION
This maintenance update:
 - Adds the `start.sh` script to the deployment pipeline for Circle.
 - Updates the assessment report content type slightly.
 - Updates the blog authors taxonomy.
 - Removes the requirement for published content from the DSS Assessment Results view.
 - Adds the assessment reports content type to the Editorial workflow.