### PR TITLE
Replace the Mailchimp API key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "drupal/weight": "3.0",
         "drupal/wysiwyg_template": "2.0-beta1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "v1.5.0",
+        "govau/dta-gov-au": "1.5.1",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",
         "oomphinc/composer-installers-extender": "1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "409d04d0d9c16ecb4283eb39a11d9076",
+    "content-hash": "87cc91d9f251575a6505b483fba56b5f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7573,16 +7573,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "v1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "5352cc5844d770db250d1ea4020ec07bc35106d8"
+                "reference": "1ebefacfc34dd792468ece94e7decd320a1efab2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/5352cc5844d770db250d1ea4020ec07bc35106d8",
-                "reference": "5352cc5844d770db250d1ea4020ec07bc35106d8",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/1ebefacfc34dd792468ece94e7decd320a1efab2",
+                "reference": "1ebefacfc34dd792468ece94e7decd320a1efab2",
                 "shasum": ""
             },
             "require": {
@@ -7600,7 +7600,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2018-08-23T06:00:21+00:00"
+            "time": "2018-08-23T06:55:19+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/mailchimp.settings.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/mailchimp.settings.yml
@@ -1,4 +1,4 @@
-api_key: 8ca3b537966b5c20972362cc5f8197c2-us12
+api_key: impy-and-chimpy
 cron: false
 batch_limit: 100
 api_classname: Mailchimp\Mailchimp

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -867,26 +867,29 @@ if(isset($_ENV['VCAP_SERVICES'])) {
 }
 
 /*
-* The following code block gets the SMTP credentials from the environment.
+* The following code block gets the SMTP and Mailchimp credentials from the environment.
 * If a local.settings.php file exists, it will read that instead so make sure
 * that that file is not pushed to anything.
 */
 
 if(isset($_ENV['VCAP_SERVICES'])) {
   $service_blob = json_decode($_ENV['VCAP_SERVICES'], true);
-  $smtp_service = array();
+  $service = array();
   foreach($service_blob as $service_provider => $service_list) {
     foreach ($service_list as $some_service) {
       // look for a service where the name is 'ups-website-redev'
       if ($some_service['name'] === 'ups-website-redev') {
-        $smtp_service[] = $some_service;
+        $service[] = $some_service;
       }
     }
   }
 
   // Set the relevant settings.
 
-  $config['swiftmailer.transport']['smtp_credentials']['swiftmailer']['password'] = $smtp_service[0]['credentials']['SMTP_PASSWORD'];
+  $config['swiftmailer.transport']['smtp_credentials']['swiftmailer']['password'] = $service[0]['credentials']['SMTP_PASSWORD'];
+
+  $config['mailchimp.settings']['api_key'] = $service[0]['credentials']['MAILCHIMP_API_KEY'];
+
 } else {
   $config['swiftmailer.transport']['smtp_credentials']['swiftmailer']['password'] = '';
 }


### PR DESCRIPTION
This commit replace the Mailchimp API key with a fake one, and updates `settings.php` to access the additional info in the UPS.