### PR TITLE
Turn off commenting

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.anonymous.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.anonymous.yml
@@ -9,10 +9,7 @@ label: 'Anonymous user'
 weight: -10
 is_admin: false
 permissions:
-  - 'access comments'
   - 'access content'
-  - 'edit own comments'
-  - 'post comments'
   - 'restful get comments'
   - 'restful get me'
   - 'restful post comments'


### PR DESCRIPTION
This commit merely turns off commenting for anonymous users by updating the permissions so the system can be deployed without making it live.