### PR TITLE
Making tags functional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "drupal/weight": "3.0",
         "drupal/wysiwyg_template": "2.0-beta1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "1.5.2",
+        "govau/dta-gov-au": "1.5.3",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",
         "oomphinc/composer-installers-extender": "1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80655c63aed1509171d1c3bc17a0b14b",
+    "content-hash": "8745ee8f80faae99a84c8852c96c231d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7575,16 +7575,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "4643173bbdc5eec6025259c12d670e443905a767"
+                "reference": "d1f53fe7a781593b489b5db81f9056b8fc39943c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/4643173bbdc5eec6025259c12d670e443905a767",
-                "reference": "4643173bbdc5eec6025259c12d670e443905a767",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/d1f53fe7a781593b489b5db81f9056b8fc39943c",
+                "reference": "d1f53fe7a781593b489b5db81f9056b8fc39943c",
                 "shasum": ""
             },
             "require": {
@@ -7602,7 +7602,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2018-08-28T04:59:35+00:00"
+            "time": "2018-08-29T00:36:52+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.blog_post.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.blog_post.full.yml
@@ -407,7 +407,7 @@ content:
     weight: 2
     label: inline
     settings:
-      link: false
+      link: true
     third_party_settings:
       empty_fields:
         handler: ''

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.full.yml
@@ -259,7 +259,7 @@ content:
     weight: 2
     label: inline
     settings:
-      link: false
+      link: true
     third_party_settings:
       empty_fields:
         handler: ''

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.extension.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.extension.yml
@@ -64,7 +64,6 @@ module:
   image_style_quality: 0
   imce: 0
   inline_form_errors: 0
-  kint: 0
   layout_discovery: 0
   link: 0
   link_css: 0

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_tags.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/rabbit_hole.behavior_settings.taxonomy_vocabulary_tags.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: taxonomy_vocabulary_tags
-action: page_redirect
-allow_override: 1
+action: display_page
+allow_override: 0
 redirect: '<front>'
 redirect_code: 301

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.taxonomy_term.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.taxonomy_term.yml
@@ -3,8 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.card
+    - node.type.blog_post
+    - node.type.landing_page
+    - node.type.landing_page_level_2
+    - node.type.news_item
+    - node.type.page
   module:
+    - datetime
     - node
     - taxonomy
     - user
@@ -51,12 +57,17 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       pager:
-        type: mini
+        type: full
         options:
-          items_per_page: 10
+          items_per_page: 20
           offset: 0
           id: 0
           total_pages: 0
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -65,9 +76,7 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          quantity: 9
       sorts:
         sticky:
           id: sticky
@@ -81,19 +90,19 @@ display:
           exposed: false
           expose:
             label: ''
-        created:
-          id: created
-          table: taxonomy_index
-          field: created
-          order: DESC
-          plugin_id: date
+        field_date_value:
+          id: field_date_value
+          table: node__field_date
+          field: field_date_value
           relationship: none
           group_type: group
           admin_label: ''
+          order: ASC
           exposed: false
           expose:
             label: ''
           granularity: second
+          plugin_id: datetime
       arguments:
         tid:
           id: tid
@@ -213,17 +222,61 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            blog_post: blog_post
+            landing_page_level_2: landing_page_level_2
+            landing_page: landing_page
+            news_item: news_item
+            page: page
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
       style:
         type: default
         options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
+          row_class: 'col-xs-12 col-sm-6 col-md-4'
+          default_row_class: false
           uses_fields: false
       row:
         type: 'entity:node'
         options:
-          view_mode: teaser
+          relationship: none
+          view_mode: card
       header:
         entity_taxonomy_term:
           id: entity_taxonomy_term
@@ -245,6 +298,7 @@ display:
       display_extenders: {  }
       link_url: ''
       link_display: page_1
+      css_class: au-cards--blogs-news
     cache_metadata:
       contexts:
         - 'languages:language_interface'
@@ -302,7 +356,25 @@ display:
         type: views_query
         options: {  }
       path: taxonomy/term/%
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
+      style:
+        type: html_list
+        options:
+          row_class: 'col-xs-12 col-sm-6 col-md-4'
+          default_row_class: false
+          uses_fields: false
+          type: ul
+          wrapper_class: au-body
+          class: 'au-card-list au-card-list--matchheight'
+      defaults:
+        style: false
+        row: false
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: card
     cache_metadata:
       contexts:
         - 'languages:language_interface'


### PR DESCRIPTION
This commit resolves an ongoing problem discovered during user research: users expect to be able to navigate across content through tags. This commit adds the functionality.
 - Adds links to tags on the blog post and news item full display mode.
 - Removes the kint module.
 - Updates rabbit hole behaviour.
 - Updates the taxonomy term view.
 - Updates the theme to 1.5.3.