### PR TITLE
HTML file upload

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.base_field_override.node.miscellaneous_file.promote.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.base_field_override.node.miscellaneous_file.promote.yml
@@ -1,0 +1,22 @@
+uuid: 0be990cd-d079-479b-a0ba-127787e23339
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.miscellaneous_file
+id: node.miscellaneous_file.promote
+field_name: promote
+entity_type: node
+bundle: miscellaneous_file
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.base_field_override.node.miscellaneous_file.status.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.base_field_override.node.miscellaneous_file.status.yml
@@ -1,0 +1,22 @@
+uuid: a2d9cf5c-1d04-4c3a-bf49-2e5b24b09b0e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.miscellaneous_file
+id: node.miscellaneous_file.status
+field_name: status
+entity_type: node
+bundle: miscellaneous_file
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.miscellaneous_file.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.miscellaneous_file.default.yml
@@ -1,0 +1,89 @@
+uuid: 3d02f73c-af86-4411-b3a8-dda83bd4b399
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.miscellaneous_file.field_file
+    - node.type.miscellaneous_file
+  module:
+    - content_moderation
+    - field_layout
+    - file
+    - layout_discovery
+    - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
+id: node.miscellaneous_file.default
+targetEntityType: node
+bundle: miscellaneous_file
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_file:
+    weight: 121
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    region: content
+hidden: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.miscellaneous_file.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.miscellaneous_file.default.yml
@@ -1,0 +1,27 @@
+uuid: e6c526ad-b0bf-40f1-8cba-825b8a14c7ba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.miscellaneous_file.field_file
+    - node.type.miscellaneous_file
+  module:
+    - file
+    - user
+id: node.miscellaneous_file.default
+targetEntityType: node
+bundle: miscellaneous_file
+mode: default
+content:
+  field_file:
+    weight: 101
+    label: above
+    settings:
+      use_description_as_link_text: true
+    third_party_settings: {  }
+    type: file_default
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.miscellaneous_file.teaser.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.miscellaneous_file.teaser.yml
@@ -1,0 +1,18 @@
+uuid: 0d368e33-ef6e-4463-b123-78ddcda7221b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.miscellaneous_file
+  module:
+    - user
+id: node.miscellaneous_file.teaser
+targetEntityType: node
+bundle: miscellaneous_file
+mode: teaser
+content:
+  links:
+    weight: 100
+    region: content
+hidden: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.miscellaneous_file.field_file.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.miscellaneous_file.field_file.yml
@@ -1,0 +1,46 @@
+uuid: dd36f576-c139-47d5-be82-bcd8ba6ab586
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_file
+    - node.type.miscellaneous_file
+  module:
+    - file
+    - filefield_paths
+third_party_settings:
+  filefield_paths:
+    enabled: false
+    file_path:
+      value: '[date:custom:Y]-[date:custom:m]'
+      options:
+        slashes: false
+        pathauto: false
+        transliterate: false
+    redirect: false
+    retroactive_update: false
+    active_updating: false
+    file_name:
+      value: '[file:ffp-name-only-original].[file:ffp-extension-original]'
+      options:
+        slashes: false
+        pathauto: false
+        transliterate: false
+id: node.miscellaneous_file.field_file
+field_name: field_file
+entity_type: node
+bundle: miscellaneous_file
+label: File
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: html
+  file_extensions: 'html htm'
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_file.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_file.yml
@@ -1,0 +1,23 @@
+uuid: f4f5f1ee-7fd6-4a66-8c28-4bebcace3ae4
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_file
+field_name: field_file
+entity_type: node
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: s3
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/node.type.miscellaneous_file.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/node.type.miscellaneous_file.yml
@@ -1,0 +1,23 @@
+uuid: 03093061-1353-4c11-90ed-570c704716c7
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - node_title_help_text
+    - wysiwyg_template
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  node_title_help_text:
+    title_help: ''
+  wysiwyg_template:
+    default_template: ''
+name: 'HTML file'
+type: miscellaneous_file
+description: 'This content type is used for uploading miscellaneous HTML files to the site.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/rabbit_hole.behavior_settings.node_type_miscellaneous_file.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/rabbit_hole.behavior_settings.node_type_miscellaneous_file.yml
@@ -1,0 +1,9 @@
+uuid: b1718baa-3742-4716-8d29-283a436ae5ec
+langcode: en
+status: true
+dependencies: {  }
+id: node_type_miscellaneous_file
+action: display_page
+allow_override: 1
+redirect: ''
+redirect_code: 301


### PR DESCRIPTION
This commit adds a content type for uploading miscellaneous HTML files. This is ostensibly to enable the respond.js proxy system, but could also be used to upload any other file for hosting purposes.