### PR TITLE
Update to config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         "drupal/weight": "3.0",
         "drupal/wysiwyg_template": "2.0-beta1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "1.7.3",
+        "govau/dta-gov-au": "1.7.4",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",
         "oomphinc/composer-installers-extender": "1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2b87f72b9b450cd9bea25b0e18b792f",
+    "content-hash": "5ccd16b66333df159ba61db2e6f8173a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7760,16 +7760,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "1.7.3",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "752b1bdfa724b332ae990f358a03d6797272243c"
+                "reference": "5202d65b2ae4edfe1dbdf8716394c3039b149cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/752b1bdfa724b332ae990f358a03d6797272243c",
-                "reference": "752b1bdfa724b332ae990f358a03d6797272243c",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/5202d65b2ae4edfe1dbdf8716394c3039b149cdf",
+                "reference": "5202d65b2ae4edfe1dbdf8716394c3039b149cdf",
                 "shasum": ""
             },
             "require": {
@@ -7787,7 +7787,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2018-11-19T06:29:47+00:00"
+            "time": "2018-11-19T10:10:47+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.booknavigation.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.booknavigation.yml
@@ -11,7 +11,7 @@ dependencies:
 id: booknavigation
 theme: dta_gov_au
 region: disabled
-weight: -10
+weight: -13
 provider: null
 plugin: book_navigation
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.booknavigation_2.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.booknavigation_2.yml
@@ -8,8 +8,8 @@ dependencies:
     - dta_gov_au
 id: booknavigation_2
 theme: dta_gov_au
-region: content
-weight: -2
+region: disabled
+weight: -8
 provider: null
 plugin: book_navigation
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.breadcrumbs_2.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.breadcrumbs_2.yml
@@ -9,7 +9,7 @@ dependencies:
 id: breadcrumbs_2
 theme: dta_gov_au
 region: disabled
-weight: -11
+weight: -14
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.dtslandingpagecontent.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.dtslandingpagecontent.yml
@@ -11,7 +11,7 @@ dependencies:
 id: dtslandingpagecontent
 theme: dta_gov_au
 region: disabled
-weight: 0
+weight: -12
 provider: null
 plugin: 'block_content:74c07265-788d-4db0-8bcf-e9681296b452'
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.socialauthlogin.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.socialauthlogin.yml
@@ -10,7 +10,7 @@ dependencies:
 id: socialauthlogin
 theme: dta_gov_au
 region: disabled
-weight: -12
+weight: -15
 provider: null
 plugin: social_auth_login
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__digital_transformation_strategy_themes_block_1.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__digital_transformation_strategy_themes_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__digital_transformation_strategy_themes_block_1
 theme: dta_gov_au
 region: disabled
-weight: 0
+weight: -10
 provider: null
 plugin: 'views_block:digital_transformation_strategy_themes-block_1'
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__digital_transformation_strategy_themes_block_2.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__digital_transformation_strategy_themes_block_2.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__digital_transformation_strategy_themes_block_2
 theme: dta_gov_au
 region: disabled
-weight: 0
+weight: -9
 provider: null
 plugin: 'views_block:digital_transformation_strategy_themes-block_2'
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__roadmaps_2_block_1.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.views_block__roadmaps_2_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__roadmaps_2_block_1
 theme: dta_gov_au
 region: disabled
-weight: 0
+weight: -11
 provider: null
 plugin: 'views_block:roadmaps_2-block_1'
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.roadmap_2_user_experience_.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.roadmap_2_user_experience_.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.roadmap_2_user_experience_.field_accelerated
     - field.field.node.roadmap_2_user_experience_.field_audience
     - field.field.node.roadmap_2_user_experience_.field_body
     - field.field.node.roadmap_2_user_experience_.field_goal_achieved
@@ -28,12 +29,19 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_accelerated:
+    weight: 6
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_audience:
-    weight: 5
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -47,7 +55,7 @@ content:
     type: text_textarea
     region: content
   field_goal_achieved:
-    weight: 4
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }
@@ -66,20 +74,20 @@ content:
     type: options_buttons
     region: content
   field_weight:
-    weight: 7
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: weight_selector
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 13
+    weight: 14
     settings: {  }
     region: content
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -87,21 +95,21 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 14
+    weight: 15
     region: content
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -114,7 +122,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -122,7 +130,7 @@ content:
     region: content
     third_party_settings: {  }
   url_redirects:
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.roadmap_2_user_experience_.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.roadmap_2_user_experience_.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.roadmap_2_user_experience_.field_accelerated
     - field.field.node.roadmap_2_user_experience_.field_audience
     - field.field.node.roadmap_2_user_experience_.field_body
     - field.field.node.roadmap_2_user_experience_.field_goal_achieved
@@ -19,6 +20,16 @@ targetEntityType: node
 bundle: roadmap_2_user_experience_
 mode: default
 content:
+  field_accelerated:
+    weight: 107
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_audience:
     weight: 106
     label: above

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.roadmap_2_user_experience_.field_accelerated.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.roadmap_2_user_experience_.field_accelerated.yml
@@ -1,0 +1,23 @@
+uuid: 2f2c6ad8-9181-4a93-ae4e-cc57c1daf67f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accelerated
+    - node.type.roadmap_2_user_experience_
+id: node.roadmap_2_user_experience_.field_accelerated
+field_name: field_accelerated
+entity_type: node
+bundle: roadmap_2_user_experience_
+label: Accelerated
+description: 'Select this if the initiative has been ''accelerated''.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Accelerated
+  off_label: 'Not accelerated'
+field_type: boolean

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_accelerated.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_accelerated.yml
@@ -1,0 +1,18 @@
+uuid: cf186cac-fab0-4f07-b7ba-4dd22cd8613e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_accelerated
+field_name: field_accelerated
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_audience.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_audience.yml
@@ -16,10 +16,10 @@ settings:
       label: People
     -
       value: business
-      label: Business
+      label: Businesses
     -
       value: people-business
-      label: 'People and business'
+      label: 'People and businesses'
   allowed_values_function: ''
 module: options
 locked: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.roadmaps_2.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.roadmaps_2.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_accelerated
     - field.storage.node.field_audience
     - field.storage.node.field_body
     - field.storage.node.field_goal_achieved
@@ -35,7 +36,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'create roadmap_2_user_experience_ content'
+          perm: 'access content'
       cache:
         type: tag
         options: {  }
@@ -92,7 +93,7 @@ display:
               field: field_audience
               rendered: false
               rendered_strip: false
-          row_class: 'roadmap-card{{ field_goal_achieved }} {{ name }}'
+          row_class: 'roadmap-card{{ field_goal_achieved }}{{ field_accelerated }} {{ name }}'
           default_row_class: false
       row:
         type: fields
@@ -612,6 +613,71 @@ display:
           entity_type: taxonomy_term
           entity_field: name
           plugin_id: term_name
+        field_accelerated:
+          id: field_accelerated
+          table: node__field_accelerated
+          field: field_accelerated
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: "{% if field_accelerated %}\r\n{{ \" \" ~ field_accelerated }}\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: accelerated
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         type:
           id: type
@@ -749,6 +815,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_accelerated'
         - 'config:field.storage.node.field_audience'
         - 'config:field.storage.node.field_body'
         - 'config:field.storage.node.field_goal_achieved'
@@ -777,6 +844,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_accelerated'
         - 'config:field.storage.node.field_audience'
         - 'config:field.storage.node.field_body'
         - 'config:field.storage.node.field_goal_achieved'
@@ -832,6 +900,7 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_accelerated'
         - 'config:field.storage.node.field_audience'
         - 'config:field.storage.node.field_body'
         - 'config:field.storage.node.field_goal_achieved'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/wysiwyg_template.wysiwyg_template.accordion.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/wysiwyg_template.wysiwyg_template.accordion.yml
@@ -11,6 +11,7 @@ body:
 weight: null
 node_types:
   - blog_post
+  - book
   - govcms_event
   - landing_page
   - landing_page_level_2


### PR DESCRIPTION
This config update:
 - Removes the book nav.
 - Changes the weights of a bunch of blocks as a result
 - Adds a new field to the Roadmap 2018 content type and updates the Roadmap view to add the 'accelerated' class.
 - Updates the 'audience' field to correct the titles.
 - Enables the accordion template for book pages.

It also updates the theme to 1.7.4.