### PR TITLE
Fix for indented images on blog pages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
         "drupal/weight": "3.0",
         "drupal/wysiwyg_template": "2.0-beta1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "1.7.5",
+        "govau/dta-gov-au": "1.8.0",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",
         "oomphinc/composer-installers-extender": "1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f933b91bf4bef2d581df8c8293c3c195",
+    "content-hash": "bfab97d6616923e43dfbae262c384394",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5665,7 +5665,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -7885,16 +7885,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "1.7.5",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "c8b78a4475c1d66d855b2c1afc1b2990e87a00ea"
+                "reference": "916ec56c5d53acc950814e336587f66e5cb7dfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/c8b78a4475c1d66d855b2c1afc1b2990e87a00ea",
-                "reference": "c8b78a4475c1d66d855b2c1afc1b2990e87a00ea",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/916ec56c5d53acc950814e336587f66e5cb7dfd8",
+                "reference": "916ec56c5d53acc950814e336587f66e5cb7dfd8",
                 "shasum": ""
             },
             "require": {
@@ -7912,7 +7912,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2018-11-19T21:07:35+00:00"
+            "time": "2018-11-21T01:51:29+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.book.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.book.full.yml
@@ -292,6 +292,7 @@ content:
 hidden:
   field_index_image: true
   field_related_content: true
+  field_short_name: true
   field_summary: true
   field_theme: true
   links: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.full.yml
@@ -141,6 +141,8 @@ content:
       timezone_override: ''
       date_format: 'M j, Y'
     third_party_settings:
+      empty_fields:
+        handler: ''
       ds:
         ft:
           id: expert
@@ -157,7 +159,7 @@ content:
             fis-cl: ''
             fis-at: ''
             fi: true
-            fi-el: p
+            fi-el: span
             fi-cl: au-date
             fi-at: ''
             suffix: ''


### PR DESCRIPTION
This commit updates the config for the news item full display to fix incorrectly indented tags and other information. It updates the theme to 1.8.0 which includes the related style update.