### PR TITLE
Content type image configuration update

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.image.teaser.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.image.teaser.yml
@@ -17,4 +17,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  field_image: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_facebook_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_facebook_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 940x788
-  min_resolution: 940x788
+  max_resolution: 940x940
+  min_resolution: 940x940
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_index_image.yml
@@ -43,7 +43,7 @@ settings:
   max_resolution: 450x300
   min_resolution: 300x200
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_linkedin_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_linkedin_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1200x628
-  min_resolution: 1200x628
+  max_resolution: 1200x1200
+  min_resolution: 1200x1200
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_twitter_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_twitter_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1024x512
-  min_resolution: 1024x512
+  max_resolution: 1024x1024
+  min_resolution: 1024x1024
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_facebook_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_facebook_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 940x768
-  min_resolution: 940x768
+  max_resolution: 940x940
+  min_resolution: 940x940
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_index_image.yml
@@ -43,7 +43,7 @@ settings:
   max_resolution: 450x300
   min_resolution: 300x200
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_linkedin_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_linkedin_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1200x628
-  min_resolution: 1200x628
+  max_resolution: 1200x1200
+  min_resolution: 1200x1200
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_twitter_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_twitter_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1024x512
-  min_resolution: 1024x512
+  max_resolution: 1024x1024
+  min_resolution: 1024x1024
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_facebook_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_facebook_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 940x768
-  min_resolution: 940x768
+  max_resolution: 940x940
+  min_resolution: 940x940
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_index_image.yml
@@ -43,7 +43,7 @@ settings:
   max_resolution: 450x300
   min_resolution: 300x200
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_linkedin_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_linkedin_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1200x768
-  min_resolution: 1200x768
+  max_resolution: 1200x1200
+  min_resolution: 1200x1200
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_twitter_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_twitter_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1024x512
-  min_resolution: 1024x512
+  max_resolution: 1024x1024
+  min_resolution: 1024x1024
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_facebook_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_facebook_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 940x788
-  min_resolution: 940x788
+  max_resolution: 940x940
+  min_resolution: 940x940
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_index_image.yml
@@ -43,7 +43,7 @@ settings:
   max_resolution: 450x300
   min_resolution: 300x200
   alt_field: true
-  alt_field_required: true
+  alt_field_required: false
   title_field: false
   title_field_required: false
   default_image:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_linkedin_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_linkedin_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1200x628
-  min_resolution: 1200x628
+  max_resolution: 1200x1200
+  min_resolution: 1200x1200
   alt_field: true
   alt_field_required: true
   title_field: false

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_twitter_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_twitter_image.yml
@@ -40,8 +40,8 @@ settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
-  max_resolution: 1024x512
-  min_resolution: 1024x512
+  max_resolution: 1024x1024
+  min_resolution: 1024x1024
   alt_field: true
   alt_field_required: true
   title_field: false


### PR DESCRIPTION
This commit updates the configuration for image fields on most content types to relax somewhat the restrictions on images sizes, primarily to allow square images.