### PR TITLE
Update to extlink settings

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/extlink.settings.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/extlink.settings.yml
@@ -5,12 +5,12 @@ extlink_follow_no_override: true
 extlink_subdomains: false
 extlink_alert: true
 extlink_alert_text: 'You are now leaving www.dta.gov.au. Please select ''Cancel'' if you wish to stay.'
-extlink_exclude: ''
+extlink_exclude: '.*(.doc|.docx|.pdf)$'
 extlink_include: ''
 extlink_class: ext
 extlink_label: '(link is external)'
 extlink_img_class: false
-extlink_css_exclude: ''
+extlink_css_exclude: footer
 extlink_css_explicit: ''
 extlink_mailto_class: mailto
 extlink_mailto_label: '(link sends email)'


### PR DESCRIPTION
This commit stops the footer and documents from having external link icons.