### PR TITLE
Monitor cron job result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
       - image: govau/cf-cli
     working_directory: /app
     steps:
+      - checkout
       - run:
           name: Running cron
           command: ./scripts/cron.sh


### PR DESCRIPTION
When we create the task, we assign a unique name to it. Then afterwards we can check the output of `cf tasks appname` and check for one of the status strings. I'm just checking for SUCCEEDED, otherwise we will get an error notification via circle. Should do the trick.

https://docs.cloudfoundry.org/devguide/using-tasks.html#-list-tasks-running-on-an-application