### PR TITLE
Update index image requiredness

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_index_image.yml
@@ -32,7 +32,7 @@ entity_type: node
 bundle: news_item
 label: 'Index image'
 description: 'The index image is used on content listings.'
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_index_image.yml
@@ -32,7 +32,7 @@ entity_type: node
 bundle: page
 label: 'Index image'
 description: 'The index image is used on content listings.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
This commit makes the index image required for news items, and not required for pages.