### PR TITLE
Update to landing page views

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.landing_page_level_2.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.landing_page_level_2.full.yml
@@ -38,11 +38,11 @@ third_party_settings:
         - field_introduction
         - 'dynamic_block_field:node-recrtuierbox_positions_block'
         - field_body
-        - 'dynamic_block_field:node-landing_page_cards'
+        - 'dynamic_block_field:node-landing_page_cards_2_card_row'
         - 'dynamic_block_field:node-related_links_block'
     fields:
-      'dynamic_block_field:node-landing_page_cards':
-        plugin_id: 'dynamic_block_field:node-landing_page_cards'
+      'dynamic_block_field:node-landing_page_cards_2_card_row':
+        plugin_id: 'dynamic_block_field:node-landing_page_cards_2_card_row'
         weight: 6
         label: above
         formatter: default
@@ -55,23 +55,23 @@ third_party_settings:
             lbw-el: h2
             lbw-cl: sr-only
             lbw-at: ''
-            ow: true
-            ow-el: div
-            ow-cl: au-landing-page-level-2-cards
+            ow-el: ''
+            ow-cl: ''
             ow-at: ''
             fis-el: ''
             fis-cl: ''
             fis-at: ''
-            fi-el: ''
-            fi-cl: ''
+            fi: true
+            fi-el: div
+            fi-cl: au-landing-page-level-2-cards
             fi-at: ''
             suffix: ''
             lb-col: false
+            ow: false
             ow-def-at: false
             ow-def-cl: false
             fis: false
             fis-def-at: false
-            fi: false
             fi-def-at: false
       'dynamic_block_field:node-recrtuierbox_positions_block':
         plugin_id: 'dynamic_block_field:node-recrtuierbox_positions_block'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/ds.field.landing_page_cards_2_card_row.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/ds.field.landing_page_cards_2_card_row.yml
@@ -2,16 +2,8 @@ id: landing_page_cards_2_card_row
 label: 'Landing page cards: 2-card row'
 ui_limit: landing_page_level_2|full
 properties:
-  block: 'views_block:duplicate_of_landing_page_cards-block_1'
+  block: 'views_block:landing_page_cards-block_2'
   use_block_title: false
-  config:
-    id: 'views_block:duplicate_of_landing_page_cards-block_1'
-    label: ''
-    provider: views
-    label_display: visible
-    views_label: ''
-    items_per_page: none
-    context_mapping: {  }
 type: block
 type_label: 'Block field'
 entities:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_links.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_links.yml
@@ -58,7 +58,7 @@ display:
         type: html_list
         options:
           grouping: {  }
-          row_class: 'col-xs-12 col-sm-4'
+          row_class: 'col-xs-12 col-sm-6'
           default_row_class: false
           uses_fields: true
           type: ul
@@ -327,7 +327,8 @@ display:
     display_title: 'Related links block'
     position: 1
     display_options:
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender: {  }
       display_description: 'Displays related links for a page.'
       allow:
         items_per_page: false


### PR DESCRIPTION
This commit updates landing page views, both menu children and related links, to be 2-up blocks instead of three.