### PR TITLE
Add standalone mailchimp form

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.dta_gov_au_views_block__contact_module_block_1.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.dta_gov_au_views_block__contact_module_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: dta_gov_au_views_block__contact_module_block_1
 theme: dta_gov_au
 region: content
-weight: 0
+weight: 1
 provider: null
 plugin: 'views_block:contact_module-block_1'
 settings:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.mailchimpsubscriptionformsignupforupdates.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/block.block.mailchimpsubscriptionformsignupforupdates.yml
@@ -1,0 +1,26 @@
+uuid: bf43a924-b4f3-41fe-ba94-d33ce0a1341d
+langcode: en
+status: true
+dependencies:
+  module:
+    - mailchimp_signup
+    - system
+  theme:
+    - dta_gov_au
+id: mailchimpsubscriptionformsignupforupdates
+theme: dta_gov_au
+region: content
+weight: 0
+provider: null
+plugin: 'mailchimp_signup_subscribe_block:sign_up_for_updates'
+settings:
+  id: 'mailchimp_signup_subscribe_block:sign_up_for_updates'
+  label: 'Sign-up for updates'
+  provider: mailchimp_signup
+  label_display: visible
+visibility:
+  request_path:
+    id: request_path
+    pages: /news-and-blogs/subscribe-updates
+    negate: false
+    context_mapping: {  }

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -28,6 +28,12 @@ default:
         - '\Drupal\DrupalExtension\Context\MinkContext'
       paths:
         features:           %paths.base%/features/admin
+    engagement:
+      contexts:
+        - '\Drupal\DrupalExtension\Context\DrupalContext'
+        - '\Drupal\DrupalExtension\Context\MinkContext'
+      paths:
+        features:           %paths.base%/features/engagement
   extensions:
     Behat\MinkExtension:
       #base_url:             'Set via environment variables'

--- a/tests/behat/features/engagement/mailchimp.feature
+++ b/tests/behat/features/engagement/mailchimp.feature
@@ -1,0 +1,41 @@
+@api
+
+Feature: Mailchimp signup
+  In order to receive notifications of new blogs and news items
+  As a user
+  I need to be able to sign up to Mailchimp through the site.
+
+  Background:
+    Given "news_item" content:
+    | title     | field_date | field_body  | field_summary | moderation_state | status |
+    | Test news | 1/1/2018   | placeholder | placeholder   | published        | 1      |
+    And "blog_post" content:
+    | title     | field_date | field_body  | field_summary | moderation_state | status |
+    | Test blog | 1/1/2018   | placeholder | placeholder   | published        | 1      |
+    And "page" content:
+    | title                | field_introduction | field_body  | field_summary | moderation_state | status |
+    | Subscribe to updates | placeholder        | placeholder | placeholder   | published        | 1      |
+    And I am logged in as a user with the "administrator" role
+    When I am on "subscribe-updates"
+    And I click "Edit" in the "content" region
+    And I uncheck "Generate automatic URL alias"
+    And I fill in "/news-and-blogs/subscribe-updates" for "URL alias"
+    And I press "Save"
+    And I am an anonymous user
+
+  @anon @mailchimp @news
+  Scenario: Form on news pages
+    When I am on "news/test-news"
+    Then I should see an "form#mailchimp-signup-subscribe-block-sign-up-for-updates-form" element
+
+  @anon @mailchimp @blogs
+  Scenario: Form on blogs pages
+    When I am on "blogs/test-blog"
+    Then I should see an "form#mailchimp-signup-subscribe-block-sign-up-for-updates-form" element
+
+
+  @anon @mailchimp
+  Scenario: Standalone form
+    When I am on "news-and-blogs/subscribe-updates"
+    Then the response status code should be 200
+    And I should see an "form#mailchimp-signup-subscribe-block-sign-up-for-updates-form" element


### PR DESCRIPTION
This commit adds the standalone mailchimp form to the Subscribe page. Also adds tests.