### PR TITLE
Patch for core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -237,7 +237,8 @@
             "Views RSS feeds have validation issues": "https://www.drupal.org/files/issues/d8-rss-validation-atom-link-missing-1337894-25.patch",
             "Allow users with access to unpublished nodes to create unpublished books": "https://www.drupal.org/files/issues/26552-133.patch",
             "Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2918537-36.patch",
-            "Views filter 'Published status or admin user' not checking 'View any unpublished content' permission": "https://www.drupal.org/files/issues/2019-03-12/3030477-5.patch"
+            "Views filter 'Published status or admin user' not checking 'View any unpublished content' permission": "https://www.drupal.org/files/issues/2019-03-12/3030477-5.patch",
+            "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch"
           },
           "drupal/ie8": {
             "drupal.js Incompatible in D8.5": "https://www.drupal.org/files/issues/2018-03-30/drupal_js.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "609cc03233c0807fcc20fc0e26f1a3b0",
+    "content-hash": "63a3148e3f0ef9c5375a5f9615ea4ec4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3183,7 +3183,8 @@
                     "Views RSS feeds have validation issues": "https://www.drupal.org/files/issues/d8-rss-validation-atom-link-missing-1337894-25.patch",
                     "Allow users with access to unpublished nodes to create unpublished books": "https://www.drupal.org/files/issues/26552-133.patch",
                     "Cannot save unpublished versions of published content for users without manage book privileges": "https://www.drupal.org/files/issues/2918537-36.patch",
-                    "Views filter 'Published status or admin user' not checking 'View any unpublished content' permission": "https://www.drupal.org/files/issues/2019-03-12/3030477-5.patch"
+                    "Views filter 'Published status or admin user' not checking 'View any unpublished content' permission": "https://www.drupal.org/files/issues/2019-03-12/3030477-5.patch",
+                    "Allow menu items which link to unpublished nodes to be selected in the parent item selector": "https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch"
                 }
             },
             "autoload": {

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -6,4 +6,5 @@ projects[drupal][patch][] = https://www.drupal.org/files/issues/d8-rss-validatio
 projects[drupal][patch][] = https://www.drupal.org/files/issues/26552-133.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2918537-36.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2019-03-12/3030477-5.patch
+projects[drupal][patch][] = https://www.drupal.org/files/issues/drupal-core-allow-menu-items-to-link-to-unpublished-2807629-7-8.3.x.patch
 projects[drupal][version] = 8.6.15


### PR DESCRIPTION
Another patch for core to resolve the issue with authors not being able to select unpublished nodes as menu parents.