### PR TITLE
Ensure blog summaries show in related links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,7 +175,7 @@
         "drupal/weight": "3.1",
         "drupal/wysiwyg_template": "2.1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "1.9.10",
+        "govau/dta-gov-au": "1.9.12",
         "govau/tadpole": "1.1",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8345f2acf8d2f635632d2f55e1794346",
+    "content-hash": "1249f4d538d5a2a720aab6cbec90830d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8929,16 +8929,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "1.9.10",
+            "version": "1.9.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "4f5bfaf63446822a4a4a0064e59e8b25945ea143"
+                "reference": "6cc81d930b3a876f90440970954c5b677329d2fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/4f5bfaf63446822a4a4a0064e59e8b25945ea143",
-                "reference": "4f5bfaf63446822a4a4a0064e59e8b25945ea143",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/6cc81d930b3a876f90440970954c5b677329d2fc",
+                "reference": "6cc81d930b3a876f90440970954c5b677329d2fc",
                 "shasum": ""
             },
             "require": {
@@ -8956,7 +8956,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2019-05-29T04:48:06+00:00"
+            "time": "2019-06-03T00:16:47+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.blog_post.home_page_blog_card.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.blog_post.home_page_blog_card.yml
@@ -1,9 +1,9 @@
-uuid: f9e3fa0b-7fcb-4539-9d02-bcd17e50c032
+uuid: e26c1023-4c4e-483f-9dfe-3f7e123794b0
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.card
+    - core.entity_view_mode.node.home_page_blog_card
     - field.field.node.blog_post.field_author
     - field.field.node.blog_post.field_body
     - field.field.node.blog_post.field_comments
@@ -27,7 +27,6 @@ dependencies:
     - empty_fields
     - field_group
     - responsive_image
-    - text
     - user
 third_party_settings:
   ds:
@@ -51,7 +50,6 @@ third_party_settings:
         - field_index_image
         - field_publication_date
         - node_title
-        - field_summary
         - group_footer
     fields:
       node_title:
@@ -97,7 +95,7 @@ third_party_settings:
       children:
         - field_publication_date
       parent_name: group_link
-      weight: 4
+      weight: 2
       format_type: html_element
       format_settings:
         id: ''
@@ -114,7 +112,6 @@ third_party_settings:
       children:
         - field_index_image
         - node_title
-        - field_summary
         - group_footer
       parent_name: ''
       weight: 0
@@ -127,10 +124,10 @@ third_party_settings:
         target_attribute: default
       label: Link
       region: hidden
-id: node.blog_post.card
+id: node.blog_post.home_page_blog_card
 targetEntityType: node
 bundle: blog_post
-mode: card
+mode: home_page_blog_card
 content:
   field_index_image:
     type: responsive_image
@@ -210,43 +207,6 @@ content:
             fis: false
             fis-def-at: false
             fi-def-at: false
-  field_summary:
-    type: text_default
-    weight: 2
-    region: ds_content
-    label: hidden
-    settings: {  }
-    third_party_settings:
-      empty_fields:
-        handler: ''
-      ds:
-        ft:
-          id: expert
-          settings:
-            lb: ''
-            prefix: ''
-            lbw-el: ''
-            lbw-cl: ''
-            lbw-at: ''
-            ow-el: ''
-            ow-cl: ''
-            ow-at: ''
-            fis-el: ''
-            fis-cl: ''
-            fis-at: ''
-            fi: true
-            fi-el: div
-            fi-cl: au-card__text
-            fi-at: ''
-            suffix: ''
-            lbw: false
-            lb-col: false
-            ow: false
-            ow-def-at: false
-            ow-def-cl: false
-            fis: false
-            fis-def-at: false
-            fi-def-at: false
 hidden:
   content_moderation_control: true
   field_author: true
@@ -258,6 +218,7 @@ hidden:
   field_linkedin_image: true
   field_review_date: true
   field_search_keywords: true
+  field_summary: true
   field_tags: true
   field_twitter_image: true
   links: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.card.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.card.yml
@@ -24,6 +24,7 @@ dependencies:
     - empty_fields
     - field_group
     - responsive_image
+    - text
     - user
 third_party_settings:
   ds:
@@ -47,6 +48,7 @@ third_party_settings:
         - field_publication_date
         - field_index_image
         - node_title
+        - field_summary
         - group_footer
     fields:
       node_title:
@@ -92,7 +94,7 @@ third_party_settings:
       children:
         - field_publication_date
       parent_name: group_link
-      weight: 3
+      weight: 4
       format_type: html_element
       format_settings:
         id: ''
@@ -109,6 +111,7 @@ third_party_settings:
       children:
         - field_index_image
         - node_title
+        - field_summary
         - group_footer
       parent_name: ''
       weight: 0
@@ -204,6 +207,43 @@ content:
             fis: false
             fis-def-at: false
             fi-def-at: false
+  field_summary:
+    type: text_default
+    weight: 3
+    region: ds_content
+    label: hidden
+    settings: {  }
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      ds:
+        ft:
+          id: expert
+          settings:
+            lb: ''
+            prefix: ''
+            lbw-el: ''
+            lbw-cl: ''
+            lbw-at: ''
+            ow-el: ''
+            ow-cl: ''
+            ow-at: ''
+            fis-el: ''
+            fis-cl: ''
+            fis-at: ''
+            fi: true
+            fi-el: div
+            fi-cl: au-card__text
+            fi-at: ''
+            suffix: ''
+            lbw: false
+            lb-col: false
+            ow: false
+            ow-def-at: false
+            ow-def-cl: false
+            fis: false
+            fis-def-at: false
+            fi-def-at: false
 hidden:
   content_moderation_control: true
   field_body: true
@@ -212,7 +252,6 @@ hidden:
   field_introduction: true
   field_linkedin_image: true
   field_search_keywords: true
-  field_summary: true
   field_tags: true
   field_twitter_image: true
   links: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.home_page_blog_card.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.news_item.home_page_blog_card.yml
@@ -1,24 +1,21 @@
-uuid: f9e3fa0b-7fcb-4539-9d02-bcd17e50c032
+uuid: ab56c47a-0674-4784-9d24-a45fdc24a973
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.card
-    - field.field.node.blog_post.field_author
-    - field.field.node.blog_post.field_body
-    - field.field.node.blog_post.field_comments
-    - field.field.node.blog_post.field_image
-    - field.field.node.blog_post.field_image_caption
-    - field.field.node.blog_post.field_index_image
-    - field.field.node.blog_post.field_introduction
-    - field.field.node.blog_post.field_linkedin_image
-    - field.field.node.blog_post.field_publication_date
-    - field.field.node.blog_post.field_review_date
-    - field.field.node.blog_post.field_search_keywords
-    - field.field.node.blog_post.field_summary
-    - field.field.node.blog_post.field_tags
-    - field.field.node.blog_post.field_twitter_image
-    - node.type.blog_post
+    - core.entity_view_mode.node.home_page_blog_card
+    - field.field.node.news_item.field_body
+    - field.field.node.news_item.field_image
+    - field.field.node.news_item.field_image_caption
+    - field.field.node.news_item.field_index_image
+    - field.field.node.news_item.field_introduction
+    - field.field.node.news_item.field_linkedin_image
+    - field.field.node.news_item.field_publication_date
+    - field.field.node.news_item.field_search_keywords
+    - field.field.node.news_item.field_summary
+    - field.field.node.news_item.field_tags
+    - field.field.node.news_item.field_twitter_image
+    - node.type.news_item
     - responsive_image.styles.index_image
   module:
     - datetime
@@ -27,7 +24,6 @@ dependencies:
     - empty_fields
     - field_group
     - responsive_image
-    - text
     - user
 third_party_settings:
   ds:
@@ -38,7 +34,7 @@ third_party_settings:
       entity_classes: all_classes
       settings:
         wrappers:
-          ds_content: article
+          ds_content: div
         outer_wrapper: div
         attributes: ''
         link_attribute: ''
@@ -48,15 +44,14 @@ third_party_settings:
     regions:
       ds_content:
         - group_link
-        - field_index_image
         - field_publication_date
+        - field_index_image
         - node_title
-        - field_summary
         - group_footer
     fields:
       node_title:
         plugin_id: node_title
-        weight: 1
+        weight: 2
         label: hidden
         formatter: default
         settings:
@@ -97,7 +92,7 @@ third_party_settings:
       children:
         - field_publication_date
       parent_name: group_link
-      weight: 4
+      weight: 3
       format_type: html_element
       format_settings:
         id: ''
@@ -114,7 +109,6 @@ third_party_settings:
       children:
         - field_index_image
         - node_title
-        - field_summary
         - group_footer
       parent_name: ''
       weight: 0
@@ -127,14 +121,14 @@ third_party_settings:
         target_attribute: default
       label: Link
       region: hidden
-id: node.blog_post.card
+id: node.news_item.home_page_blog_card
 targetEntityType: node
-bundle: blog_post
-mode: card
+bundle: news_item
+mode: home_page_blog_card
 content:
   field_index_image:
     type: responsive_image
-    weight: 0
+    weight: 1
     region: ds_content
     label: hidden
     settings:
@@ -152,14 +146,14 @@ content:
             lbw-el: ''
             lbw-cl: ''
             lbw-at: ''
-            ow-el: div
-            ow-cl: 'au-card__image au-card__fullwidth'
+            ow-el: ''
+            ow-cl: ''
             ow-at: ''
             fis-el: ''
             fis-cl: ''
             fis-at: ''
             fi: true
-            fi-el: ''
+            fi-el: div
             fi-cl: 'au-card__image au-card__fullwidth'
             fi-at: ''
             suffix: ''
@@ -210,54 +204,15 @@ content:
             fis: false
             fis-def-at: false
             fi-def-at: false
-  field_summary:
-    type: text_default
-    weight: 2
-    region: ds_content
-    label: hidden
-    settings: {  }
-    third_party_settings:
-      empty_fields:
-        handler: ''
-      ds:
-        ft:
-          id: expert
-          settings:
-            lb: ''
-            prefix: ''
-            lbw-el: ''
-            lbw-cl: ''
-            lbw-at: ''
-            ow-el: ''
-            ow-cl: ''
-            ow-at: ''
-            fis-el: ''
-            fis-cl: ''
-            fis-at: ''
-            fi: true
-            fi-el: div
-            fi-cl: au-card__text
-            fi-at: ''
-            suffix: ''
-            lbw: false
-            lb-col: false
-            ow: false
-            ow-def-at: false
-            ow-def-cl: false
-            fis: false
-            fis-def-at: false
-            fi-def-at: false
 hidden:
   content_moderation_control: true
-  field_author: true
   field_body: true
-  field_comments: true
   field_image: true
   field_image_caption: true
   field_introduction: true
   field_linkedin_image: true
-  field_review_date: true
   field_search_keywords: true
+  field_summary: true
   field_tags: true
   field_twitter_image: true
   links: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_mode.node.home_page_blog_card.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_mode.node.home_page_blog_card.yml
@@ -1,0 +1,10 @@
+uuid: 037b4cd9-230a-4cdd-8d1c-420ef83039c8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.home_page_blog_card
+label: 'Home page blog card'
+targetEntityType: node
+cache: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.news_and_blogs_facets.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.news_and_blogs_facets.yml
@@ -80,8 +80,8 @@ display:
         options:
           view_modes:
             'entity:node':
-              blog_post: card
-              news_item: card
+              blog_post: home_page_blog_card
+              news_item: home_page_blog_card
       fields:
         rendered_item:
           id: rendered_item
@@ -344,8 +344,8 @@ display:
         options:
           view_modes:
             'entity:node':
-              blog_post: card
-              news_item: card
+              blog_post: home_page_blog_card
+              news_item: home_page_blog_card
       filters:
         status:
           id: status

--- a/tests/behat/features/ui/related-links.feature
+++ b/tests/behat/features/ui/related-links.feature
@@ -1,0 +1,34 @@
+@api
+
+Feature: Related links
+  In order to learn more about the DTA's products, services and events
+  As a user
+  I need to be able to view related links on different content types
+
+  Background:
+    Given "blog_post" content:
+    | title             | field_body             | field_publication_date | status | moderation_state | field_summary        |
+    | Related link blog | Related link blog body | 1/1/2017               | 1      | published        | Related link blog summary |
+
+    Given "news_item" content:
+    | title             | field_body             | field_publication_date | status | moderation_state | field_summary        |
+    | Related link news | Related link news body | 1/1/2017               | 1      | published        | Related link news summary |
+
+
+    And "page" content:
+    | title       | field_body       | status | moderation_state | field_summary       | field_related_content                | field_related_content_heading |
+    | Source page | Source page body | 1      | published        | Source page summary | Related link blog, Related link news | Related links                 |
+
+    And I run cron
+
+    @anonymous @related-links
+    Scenario: Related link cards for blogs
+      When I am an anonymous user
+      And I visit "source-page"
+      Then the response status code should be 200
+      And I should see the heading "Source page"
+      And I should see the heading "Related links"
+      And I should see the heading "Related link blog"
+      And I should see the heading "Related link news"
+      And I should see the text "Related link blog summary"
+      And I should see the text "Related link news summary"


### PR DESCRIPTION
This commit updates and adds to existing display modes to make sure related links with images (notably blogs) display their summaries correctly. It also updates the theme to 1.9.12, which includes some minor changes to make the new display modes look correct.