### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -21,11 +21,11 @@ login() {
   fi
 
   if [[ "${GIT_BRANCH}" = "master" ]]; then
-    cf api $CF_PROD_API
-    cf auth "$CF_USER" "$CF_PASSWORD_PROD"
+    cf api $CF_API_PROD
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_PROD"
   else
-    cf api $CF_STAGING_API
-    cf auth "$CF_USER" "$CF_PASSWORD_STAGING"
+    cf api $CF_API_STAGING
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_STAGING"
   fi
 
   cf target -o $CF_ORG

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,11 +21,11 @@ login() {
   fi
 
   if [[ "${GIT_BRANCH}" = "master" ]]; then
-    cf api $CF_PROD_API
-    cf auth "$CF_USER" "$CF_PASSWORD_PROD"
+    cf api $CF_API_PROD
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_PROD"
   else
-    cf api $CF_STAGING_API
-    cf auth "$CF_USER" "$CF_PASSWORD_STAGING"
+    cf api $CF_API_STAGING
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_STAGING"
   fi
 
   cf target -o $CF_ORG

--- a/scripts/post-deploy.sh
+++ b/scripts/post-deploy.sh
@@ -21,11 +21,11 @@ login() {
   fi
 
   if [[ "${GIT_BRANCH}" = "master" ]]; then
-    cf api $CF_PROD_API
-    cf auth "$CF_USER" "$CF_PASSWORD_PROD"
+    cf api $CF_API_PROD
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_PROD"
   else
-    cf api $CF_STAGING_API
-    cf auth "$CF_USER" "$CF_PASSWORD_STAGING"
+    cf api $CF_API_STAGING
+    cf auth "$CF_USERNAME" "$CF_PASSWORD_STAGING"
   fi
 
   cf target -o $CF_ORG


### PR DESCRIPTION
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to
make it easier for us we need to have a standard naming convention for environment
variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use
the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent
in the above list.