### PR TITLE
Update text formats

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.media_release.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.node.media_release.default.yml
@@ -73,12 +73,9 @@ content:
     region: content
   field_tags:
     weight: 10
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete
+    type: options_select
     region: content
   moderation_state:
     type: moderation_state_default

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/editor.editor.full_rich_text.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/editor.editor.full_rich_text.yml
@@ -1,29 +1,32 @@
-uuid: be752084-d0e1-42a3-b655-e9c0c65cdb90
+uuid: 98513b99-b262-4e29-8257-8694c51776c4
 langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.commenting
+    - filter.format.full_rich_text
   module:
     - ckeditor
-format: commenting
+format: full_rich_text
 editor: ckeditor
 settings:
   toolbar:
     rows:
       -
         -
-          name: Edit
+          name: Tools
           items:
+            - TemplateSelector
             - PasteFromWord
             - Source
         -
           name: Formatting
           items:
+            - RemoveFormat
             - Bold
             - Italic
-            - Blockquote
+            - Superscript
             - Format
+            - Styles
         -
           name: Links
           items:
@@ -39,8 +42,30 @@ settings:
         -
           name: Media
           items:
+            - Blockquote
             - ImceImage
             - video_embed
+        -
+          name: Tables
+          items:
+            - tableinsert
+            - tabledelete
+            - tableproperties
+            - tablerowinsertbefore
+            - tablerowinsertafter
+            - tablerowdelete
+            - tablecolumninsertbefore
+            - tablecolumninsertafter
+            - tablecolumndelete
+            - tablecellinsertbefore
+            - tablecellinsertafter
+            - tablecelldelete
+            - tablecellproperties
+            - tablecellsmerge
+            - tablecellmergeright
+            - tablecellmergedown
+            - tablecellsplithorizontal
+            - tablecellsplitvertical
   plugins:
     drupallink:
       linkit_enabled: true
@@ -48,7 +73,7 @@ settings:
     language:
       language_list: un
     stylescombo:
-      styles: ''
+      styles: "div.au-callout|Callout: container\r\np.au-callout|Callout: paragraph\r\np.au-pullquote|Pullquote: paragraph\r\np.align-left|Align left\r\np.align-right|Align right"
     video_embed:
       defaults:
         children:

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_body.yml
@@ -10,11 +10,14 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
+    commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    summary: '0'
 id: node.assessment_report.field_body
 field_name: field_body
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_introduction.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_introduction.yml
@@ -11,10 +11,13 @@ dependencies:
 third_party_settings:
   allowed_formats:
     introduction: introduction
+    commenting: '0'
     rich_text: '0'
     administration: '0'
     html: '0'
     plain_text: '0'
+    full_rich_text: '0'
+    summary: '0'
 id: node.assessment_report.field_introduction
 field_name: field_introduction
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_pass_rationale.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_pass_rationale.yml
@@ -10,11 +10,14 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
+    commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    summary: '0'
 id: node.assessment_report.field_pass_rationale
 field_name: field_pass_rationale
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_recommendations.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.assessment_report.field_recommendations.yml
@@ -10,11 +10,14 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
+    commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    summary: '0'
 id: node.assessment_report.field_recommendations
 field_name: field_recommendations
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.blog_post.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.book.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.book.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.govcms_event.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.govcms_event.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.home_page.body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.home_page.body.yml
@@ -6,7 +6,18 @@ dependencies:
     - field.storage.node.body
     - node.type.home_page
   module:
+    - allowed_formats
     - text
+third_party_settings:
+  allowed_formats:
+    commenting: commenting
+    rich_text: '0'
+    administration: '0'
+    html: '0'
+    introduction: '0'
+    plain_text: '0'
+    full_rich_text: '0'
+    summary: '0'
 id: node.home_page.body
 field_name: body
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page.field_body.yml
@@ -6,14 +6,18 @@ dependencies:
     - field.storage.node.field_body
     - node.type.landing_page
   module:
+    - allowed_formats
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
+    commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    summary: '0'
 id: node.landing_page.field_body
 field_name: field_body
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.landing_page_level_2.field_body.yml
@@ -10,11 +10,14 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
+    commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    summary: '0'
 id: node.landing_page_level_2.field_body
 field_name: field_body
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.media_release.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.media_release.field_body.yml
@@ -10,12 +10,13 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
-    commenting: '0'
+    commenting: commenting
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'
     plain_text: '0'
+    full_rich_text: '0'
     summary: '0'
 id: node.media_release.field_body
 field_name: field_body

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.news_item.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.page.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.platforms_and_services.field_body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.node.platforms_and_services.field_body.yml
@@ -10,8 +10,9 @@ dependencies:
     - text
 third_party_settings:
   allowed_formats:
-    rich_text: rich_text
+    full_rich_text: full_rich_text
     commenting: '0'
+    rich_text: '0'
     administration: '0'
     html: '0'
     introduction: '0'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.body.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.body.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
 _core:
   default_config_hash: EBUo7qOWqaiZaQ_RC9sLY5IoDKphS34v77VIHSACmVY
 id: node.body

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_introduction.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_introduction.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: node.field_introduction
 field_name: field_introduction
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_pass_rationale.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_pass_rationale.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: node.field_pass_rationale
 field_name: field_pass_rationale
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_recommendations.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.node.field_recommendations.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - text
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: node.field_recommendations
 field_name: field_recommendations
 entity_type: node

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/filter.format.full_rich_text.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/filter.format.full_rich_text.yml
@@ -1,91 +1,58 @@
-uuid: 1b5cf969-cd0c-4f9c-a2ba-ad1a5d27e817
+uuid: 4931f1db-603e-4090-9e90-4d21cb671ba8
 langcode: en
 status: true
 dependencies:
   module:
-    - editor
     - entity_embed
     - htmlawed
     - linkit
-    - markdown
     - toc_filter
     - typogrify
     - url_embed
     - video_embed_wysiwyg
-    - wysiwyg_template_core
-name: 'Simple rich editor'
-format: commenting
-weight: -10
+name: 'Full rich text'
+format: full_rich_text
+weight: 0
 filters:
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: -43
-    settings: {  }
   entity_embed:
     id: entity_embed
     provider: entity_embed
-    status: false
-    weight: -42
-    settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: false
-    weight: -41
+    status: true
+    weight: 100
     settings: {  }
   filter_autop:
     id: filter_autop
     provider: filter
     status: true
-    weight: -49
+    weight: 0
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
-    status: false
-    weight: -40
+    status: true
+    weight: 0
     settings: {  }
   filter_html:
     id: filter_html
     provider: filter
-    status: true
-    weight: -50
+    status: false
+    weight: -10
     settings:
-      allowed_html: '<em> <strong> <blockquote> <ul> <ol> <li> <a href data-entity-substitution data-entity-type data-entity-uuid title> <p> <h2> <h3> <h4>'
-      filter_html_help: false
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title> <sup> <p class="au-callout au-pullquote align-left align-right"> <h1> <pre> <div class="au-callout">'
+      filter_html_help: true
       filter_html_nofollow: false
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -46
-    settings: {  }
-  filter_html_escape:
-    id: filter_html_escape
-    provider: filter
-    status: false
-    weight: -44
-    settings: {  }
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: false
-    weight: -35
-    settings: {  }
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -47
+    weight: 0
     settings:
       filter_url_length: 72
   filter_htmlawed:
     id: filter_htmlawed
     provider: htmlawed
     status: false
-    weight: -32
+    weight: 50
     settings:
       config: '''safe'' => 1, ''elements'' => ''a, em, strong, cite, code, ol, ul, li, dl, dt, dd, br, p'', ''deny_attribute'' => ''id, style'''
       spec: ''
@@ -95,30 +62,23 @@ filters:
     id: linkit
     provider: linkit
     status: true
-    weight: -39
+    weight: 0
     settings:
       title: false
-  markdown:
-    id: markdown
-    provider: markdown
-    status: false
-    weight: -45
-    settings:
-      markdown_library: php-markdown
   toc_filter:
     id: toc_filter
     provider: toc_filter
-    status: false
-    weight: -38
+    status: true
+    weight: 0
     settings:
       type: default
-      auto: ''
+      auto: top
       block: '0'
   TypogrifyFilter:
     id: TypogrifyFilter
     provider: typogrify
     status: false
-    weight: -34
+    weight: 10
     settings:
       smartypants_enabled: '1'
       smartypants_hyphens: '3'
@@ -135,28 +95,15 @@ filters:
       arrows: 'a:0:{}'
       fractions: 'a:0:{}'
       quotes: 'a:0:{}'
-  url_embed_convert_links:
-    id: url_embed_convert_links
-    provider: url_embed
-    status: false
-    weight: -36
-    settings:
-      url_prefix: ''
   url_embed:
     id: url_embed
     provider: url_embed
-    status: false
-    weight: -37
+    status: true
+    weight: 0
     settings: {  }
   video_embed_wysiwyg:
     id: video_embed_wysiwyg
     provider: video_embed_wysiwyg
     status: true
-    weight: -48
-    settings: {  }
-  filter_wysiwyg_cleanup:
-    id: filter_wysiwyg_cleanup
-    provider: wysiwyg_template_core
-    status: false
-    weight: -33
+    weight: 0
     settings: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.content_approver.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.content_approver.yml
@@ -75,6 +75,7 @@ permissions:
   - 'use editorial transition publish'
   - 'use external_links transition create_new_draft'
   - 'use external_links transition publish'
+  - 'use text format full_rich_text'
   - 'use text format introduction'
   - 'use text format rich_text'
   - 'use text format summary'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.content_editor.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.content_editor.yml
@@ -112,6 +112,7 @@ permissions:
   - 'use editorial transition needs_review'
   - 'use external_links transition create_new_draft'
   - 'use external_links transition publish'
+  - 'use text format full_rich_text'
   - 'use text format introduction'
   - 'use text format rich_text'
   - 'use text format summary'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.digital_transformation_guide_approver.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.digital_transformation_guide_approver.yml
@@ -40,6 +40,7 @@ permissions:
   - 'use editorial transition publish'
   - 'use external_links transition create_new_draft'
   - 'use external_links transition publish'
+  - 'use text format full_rich_text'
   - 'use text format introduction'
   - 'use text format rich_text'
   - 'use text format summary'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.digital_transformation_guide_author.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.digital_transformation_guide_author.yml
@@ -48,6 +48,7 @@ permissions:
   - 'use editorial transition needs_review'
   - 'use external_links transition create_new_draft'
   - 'use external_links transition publish'
+  - 'use text format full_rich_text'
   - 'use text format introduction'
   - 'use text format rich_text'
   - 'use text format summary'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.media_release_author.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.media_release_author.yml
@@ -21,6 +21,7 @@ permissions:
   - 'use dta_publishing transition create_new_draft'
   - 'use dta_publishing transition restore_to_content_design'
   - 'use dta_publishing transition technical_review'
+  - 'use text format commenting'
   - 'use text format rich_text'
   - 'use text format summary'
   - 'view any unpublished content'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.technical_reviewer.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.technical_reviewer.yml
@@ -57,6 +57,7 @@ permissions:
   - 'use dta_publishing transition technical_review'
   - 'use external_links transition create_new_draft'
   - 'use external_links transition publish'
+  - 'use text format full_rich_text'
   - 'use text format introduction'
   - 'use text format rich_text'
   - 'use text format summary'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.webform_author.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/user.role.webform_author.yml
@@ -27,6 +27,7 @@ permissions:
   - 'edit webform assets'
   - 'edit webform source'
   - 'edit webform twig'
+  - 'use text format full_rich_text'
   - 'view any webform submission'
   - 'view own unpublished content'
   - 'view own webform submission'


### PR DESCRIPTION
This commit adds a new text format, 'Full rich'. It also updates the 'Commenting' text format to be 'Simple rich'. The Full rich editor replaces all instances of the 'Full HTML' editor, while Simple rich is used only on media releases.