### PR TITLE
Update event content types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
         "drupal/weight": "3.1",
         "drupal/wysiwyg_template": "2.1",
         "drush/drush": "9.3.0",
-        "govau/dta-gov-au": "1.9.26",
+        "govau/dta-gov-au": "1.9.27",
         "govau/tadpole": "1.1",
         "harvesthq/chosen": "1.8.2",
         "imperator99/superfish": "2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94c83c34065551a4f631a124109a4f44",
+    "content-hash": "5c07b810e8d902b9a7540427d9176c96",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9003,16 +9003,16 @@
         },
         {
             "name": "govau/dta-gov-au",
-            "version": "1.9.26",
+            "version": "1.9.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/govau/dta-gov-au.git",
-                "reference": "576a6b50f79161d88d84771807ca4486e6dbe5ff"
+                "reference": "360d84f33eb6813beb55a00eb45859572efdb01e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/576a6b50f79161d88d84771807ca4486e6dbe5ff",
-                "reference": "576a6b50f79161d88d84771807ca4486e6dbe5ff",
+                "url": "https://api.github.com/repos/govau/dta-gov-au/zipball/360d84f33eb6813beb55a00eb45859572efdb01e",
+                "reference": "360d84f33eb6813beb55a00eb45859572efdb01e",
                 "shasum": ""
             },
             "require": {
@@ -9030,7 +9030,7 @@
                 "government",
                 "theme"
             ],
-            "time": "2019-09-04T08:44:46+00:00"
+            "time": "2019-09-05T06:04:48+00:00"
         },
         {
             "name": "govau/dta-uikit-base",

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.taxonomy_term.presentation_type.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_form_display.taxonomy_term.presentation_type.default.yml
@@ -1,0 +1,57 @@
+uuid: 53c3b99c-2af2-4dc3-ae6e-1ebbbf787dc4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.presentation_type.field_index_image
+    - image.style.thumbnail
+    - taxonomy.vocabulary.presentation_type
+  module:
+    - field_layout
+    - image
+    - imce
+    - layout_discovery
+    - path
+    - text
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
+id: taxonomy_term.presentation_type.default
+targetEntityType: taxonomy_term
+bundle: presentation_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 0
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  field_index_image:
+    weight: 31
+    settings:
+      preview_image_style: thumbnail
+      progress_indicator: throbber
+    third_party_settings:
+      imce:
+        enabled: false
+    type: image_image
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.home_page.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.home_page.default.yml
@@ -23,6 +23,7 @@ third_party_settings:
     regions:
       content:
         - links
+        - content_moderation_control
         - body
         - field_link_to_content
   ds_chains:
@@ -39,6 +40,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_link_to_content:
     weight: 2
     label: hidden
@@ -85,4 +91,4 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
-  content_moderation_control: true
+  search_api_excerpt: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.speaker_bio.full.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.node.speaker_bio.full.yml
@@ -14,11 +14,12 @@ dependencies:
     - field.field.node.speaker_bio.field_speaker_type
     - field.field.node.speaker_bio.field_weight
     - node.type.speaker_bio
-    - responsive_image.styles.hero_image
+    - responsive_image.styles.index_image
   module:
     - ds
     - ds_chains
     - empty_fields
+    - field_group
     - responsive_image
     - text
     - user
@@ -33,17 +34,66 @@ third_party_settings:
     regions:
       content:
         - field_image
+        - content_moderation_control
+        - field_index_image
         - field_position
         - field_orgnaisation
         - field_body
         - field_short_name
+        - group_right_column
+        - group_left_column
   ds_chains:
     fields: {  }
+  field_group:
+    group_left_column:
+      children:
+        - field_body
+        - field_short_name
+      parent_name: ''
+      weight: 20
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: 'left-column col-xs-12 col-sm-8'
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Left column'
+      region: content
+    group_right_column:
+      children:
+        - field_index_image
+        - field_position
+        - field_orgnaisation
+      parent_name: ''
+      weight: 20
+      format_type: html_element
+      format_settings:
+        id: ''
+        classes: 'right-column col-xs-12 col-sm-4'
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+      label: 'Right column'
+      region: content
 id: node.speaker_bio.full
 targetEntityType: node
 bundle: speaker_bio
 mode: full
 content:
+  content_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_body:
     weight: 4
     label: hidden
@@ -84,6 +134,45 @@ content:
             suffix: ''
             lbw: false
             lb-col: false
+            ow-def-at: false
+            ow-def-cl: false
+            fis: false
+            fis-def-at: false
+            fi: false
+            fi-def-at: false
+  field_index_image:
+    type: responsive_image
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      responsive_image_style: index_image
+      image_link: ''
+    third_party_settings:
+      empty_fields:
+        handler: ''
+      ds:
+        ft:
+          id: expert
+          settings:
+            lb: ''
+            prefix: ''
+            lbw-el: ''
+            lbw-cl: ''
+            lbw-at: ''
+            ow-el: ''
+            ow-cl: ''
+            ow-at: ''
+            fis-el: ''
+            fis-cl: ''
+            fis-at: ''
+            fi-el: ''
+            fi-cl: ''
+            fi-at: ''
+            suffix: ''
+            lbw: false
+            lb-col: false
+            ow: false
             ow-def-at: false
             ow-def-cl: false
             fis: false
@@ -205,9 +294,7 @@ content:
     type: string
     region: content
 hidden:
-  content_moderation_control: true
   field_event: true
-  field_index_image: true
   field_speaker_type: true
   field_weight: true
   links: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.taxonomy_term.presentation_type.default.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/core.entity_view_display.taxonomy_term.presentation_type.default.yml
@@ -1,0 +1,33 @@
+uuid: ba01a67b-fb09-484d-b52d-98626d617cc5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.presentation_type.field_index_image
+    - taxonomy.vocabulary.presentation_type
+  module:
+    - image
+    - text
+id: taxonomy_term.presentation_type.default
+targetEntityType: taxonomy_term
+bundle: presentation_type
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_index_image:
+    weight: 1
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.taxonomy_term.presentation_type.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.field.taxonomy_term.presentation_type.field_index_image.yml
@@ -1,0 +1,57 @@
+uuid: 996b9924-6dbd-44c8-9a1a-a5946269d8ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_index_image
+    - taxonomy.vocabulary.presentation_type
+  module:
+    - filefield_paths
+    - image
+third_party_settings:
+  filefield_paths:
+    enabled: true
+    file_path:
+      value: images/index/presentations
+      options:
+        slashes: true
+        pathauto: true
+        transliterate: true
+    redirect: true
+    retroactive_update: false
+    active_updating: false
+    file_name:
+      value: '[file:ffp-name-only-original].[file:ffp-extension-original]'
+      options:
+        slashes: true
+        pathauto: true
+        transliterate: true
+id: taxonomy_term.presentation_type.field_index_image
+field_name: field_index_image
+entity_type: taxonomy_term
+bundle: presentation_type
+label: 'Index image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: 450x300
+  min_resolution: 300x200
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.taxonomy_term.field_index_image.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/field.storage.taxonomy_term.field_index_image.yml
@@ -1,0 +1,34 @@
+uuid: 137f8b1f-26e6-400c-ac19-ac81318d2e20
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - file
+    - image
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_index_image
+field_name: field_index_image
+entity_type: taxonomy_term
+type: image
+settings:
+  uri_scheme: s3
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
This commit updates event-related content types, notably the presentation type taxonomy to include an image. Also updates the theme to 1.9.27.