### PR TITLE
Prevent archived cards showing up

### DIFF
--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.landing_page_cards.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.landing_page_cards.yml
@@ -15,7 +15,10 @@ dependencies:
     - node.type.page
     - node.type.platforms_and_services
     - responsive_image.styles.index_image
+    - workflows.workflow.dta_publishing
+    - workflows.workflow.external_links
   module:
+    - content_moderation
     - node
     - responsive_image
     - text
@@ -212,6 +215,46 @@ display:
             group_items: {  }
           entity_type: node
           plugin_id: node_status
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not in'
+          value:
+            dta_publishing-archived: dta_publishing-archived
+            external_links-archived: external_links-archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: moderation_state_filter
       sorts:
         menu_children_sort:
           id: menu_children_sort
@@ -279,7 +322,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_1:
     display_plugin: block
     id: block_1
@@ -297,7 +341,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_2:
     display_plugin: block
     id: block_2
@@ -335,7 +380,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   block_3:
     display_plugin: block
     id: block_3
@@ -737,6 +783,7 @@ display:
         - 'config:field.storage.node.field_index_image'
         - 'config:field.storage.node.field_short_name'
         - 'config:field.storage.node.field_summary'
+        - 'config:workflow_list'
   block_4:
     display_plugin: block
     id: block_4
@@ -1074,3 +1121,4 @@ display:
       tags:
         - 'config:field.storage.node.field_index_image'
         - 'config:field.storage.node.field_summary'
+        - 'config:workflow_list'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_content.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_content.yml
@@ -13,7 +13,10 @@ dependencies:
     - node.type.media_release
     - node.type.news_item
     - node.type.page
+    - workflows.workflow.dta_publishing
+    - workflows.workflow.external_links
   module:
+    - content_moderation
     - node
     - user
 id: related_content
@@ -317,6 +320,83 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not in'
+          value:
+            dta_publishing-archived: dta_publishing-archived
+            external_links-archived: external_links-archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: moderation_state_filter
+        status_extra:
+          id: status_extra
+          table: node_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: false
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: node_status
       sorts:
         title:
           id: title
@@ -355,9 +435,11 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'
   entity_reference_1:
     display_plugin: entity_reference
     id: entity_reference_1
@@ -387,6 +469,8 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:workflow_list'

--- a/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_links.yml
+++ b/docroot/sites/default/files/config_SKRbKjrsGZbCwa_q0wg8DYZpUGb3pdwwxawoq_xE0FXjABmFBcdqfoyLjvWYMn74C7COWTFr6w/sync/views.view.related_links.yml
@@ -6,7 +6,10 @@ dependencies:
     - core.entity_view_mode.node.card
     - field.storage.node.field_related_content
     - field.storage.node.field_related_content_heading
+    - workflows.workflow.dta_publishing
+    - workflows.workflow.external_links
   module:
+    - content_moderation
     - node
     - user
 id: related_links
@@ -239,6 +242,83 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: numeric
+        moderation_state:
+          id: moderation_state
+          table: node_field_data
+          field: moderation_state
+          relationship: field_related_content
+          group_type: group
+          admin_label: ''
+          operator: 'not in'
+          value:
+            dta_publishing-archived: dta_publishing-archived
+            external_links-archived: external_links-archived
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: moderation_state_filter
+        status_extra:
+          id: status_extra
+          table: node_field_data
+          field: status_extra
+          relationship: field_related_content
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: false
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          plugin_id: node_status
       sorts: {  }
       title: 'Related links'
       header:
@@ -316,11 +396,13 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_related_content'
         - 'config:field.storage.node.field_related_content_heading'
+        - 'config:workflow_list'
   related_links_block_1:
     display_plugin: block
     id: related_links_block_1
@@ -339,8 +421,10 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_related_content'
         - 'config:field.storage.node.field_related_content_heading'
+        - 'config:workflow_list'


### PR DESCRIPTION
This minor change prevents archived content appearing in cards for those with site permissions. It also prevents archived content appearing in related content entity reference views.